### PR TITLE
Document mint assertion HTTP endpoint usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,22 @@ These steps demonstrate a complete OBO delegation flow using only `curl` and the
 
 ### Step 2 – Mint an actor client assertion
 
-Use the helper to mint a signed JWT that identifies the agent and controlling OAuth client:
+Mint a signed JWT that identifies the agent and controlling OAuth client using either the HTTP API (handy for Postman or other tooling) or the CLI helper:
+
+**Option A – HTTP API**
+
+```bash
+curl -s -X POST http://localhost:8080/mint-assertion \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "actor": "agent:ingestor-42",
+        "client": "client-xyz"
+      }'
+```
+
+The response body contains `{ "assertion": "<JWT>" }`. Optional fields include `issuer`, `audience`, `instance_id`, `key_id`, and `ttl_seconds`. Defaults match the authorization server configuration (`AS_ISSUER`, `AS_DEFAULT_CLIENT_ID`, signing key ID, and a 5 minute TTL).
+
+**Option B – CLI helper**
 
 ```bash
 go run ./tools/mint_assertion \
@@ -124,7 +139,7 @@ go run ./tools/mint_assertion \
 
 Copy the output (a compact JWT). This is the `actor_token` for token exchange. Adjust the flags to customise the actor ID or execution instance.
 
-> **Note:** The helper defaults to the same symmetric signing key as the servers. If you override `AS_SIGNING_KEY_BASE64` (for example via `.env` or Docker), pass the matching value to the tool using `-key $AS_SIGNING_KEY_BASE64` or export the variable before running the command so the signature matches.
+> **Note:** Both options default to the same symmetric signing key as the servers. If you override `AS_SIGNING_KEY_BASE64` (for example via `.env` or Docker), pass the matching value to the tool using `-key $AS_SIGNING_KEY_BASE64` or supply it in the server configuration before making the API call so the signature matches.
 
 ### Step 3 – Exchange for an OBO token
 

--- a/internal/assertion/mint.go
+++ b/internal/assertion/mint.go
@@ -1,0 +1,96 @@
+package assertion
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"go_oauth2_server/internal/random"
+)
+
+var (
+	ErrMissingIssuer   = errors.New("issuer required")
+	ErrMissingAudience = errors.New("audience required")
+	ErrMissingClientID = errors.New("client id required")
+	ErrMissingActorID  = errors.New("actor id required")
+	ErrMissingKey      = errors.New("signing key required")
+)
+
+// MintOptions defines the parameters for minting a client assertion.
+type MintOptions struct {
+	Issuer     string
+	Audience   string
+	ClientID   string
+	ActorID    string
+	InstanceID string
+	SigningKey []byte
+	KeyID      string
+	TTL        time.Duration
+}
+
+// MintClientAssertion generates a signed JWT assertion using the provided options.
+func MintClientAssertion(opts MintOptions) (string, error) {
+	if len(opts.SigningKey) == 0 {
+		return "", ErrMissingKey
+	}
+	if opts.Issuer == "" {
+		return "", ErrMissingIssuer
+	}
+	if opts.Audience == "" {
+		return "", ErrMissingAudience
+	}
+	if opts.ClientID == "" {
+		return "", ErrMissingClientID
+	}
+	if opts.ActorID == "" {
+		return "", ErrMissingActorID
+	}
+	if opts.InstanceID == "" {
+		opts.InstanceID = "run-" + random.NewID()
+	}
+	if opts.TTL <= 0 {
+		opts.TTL = 5 * time.Minute
+	}
+
+	now := time.Now().UTC()
+	claims := map[string]any{
+		"iss":         opts.Issuer,
+		"sub":         opts.ActorID,
+		"aud":         opts.Audience,
+		"iat":         now.Unix(),
+		"exp":         now.Add(opts.TTL).Unix(),
+		"jti":         random.NewID(),
+		"actor":       opts.ActorID,
+		"client_id":   opts.ClientID,
+		"instance_id": opts.InstanceID,
+	}
+
+	header := map[string]any{
+		"alg": "HS256",
+		"typ": "JWT",
+	}
+	if opts.KeyID != "" {
+		header["kid"] = opts.KeyID
+	}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+
+	unsigned := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(claimsJSON)
+	mac := hmac.New(sha256.New, opts.SigningKey)
+	if _, err := mac.Write([]byte(unsigned)); err != nil {
+		return "", err
+	}
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	return unsigned + "." + sig, nil
+}


### PR DESCRIPTION
## Summary
- document how to mint assertions over the new HTTP endpoint, including optional fields and defaults
- clarify that both the API and CLI share the same signing key expectations

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_6904caf050f8832ca629f93bdc2113bf