### PR TITLE
Update project to Go 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.22 AS build
+FROM golang:1.24 AS build
 WORKDIR /app
 COPY go.mod ./
 RUN go mod download

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The project is intended for local development and demo scenarios. Tokens are JSO
 
 ## Prerequisites
 
-- Go **1.22+**
+- Go **1.24+**
 - `curl`
 - Optional: Docker & Docker Compose v2
 - Optional: `make`

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go_oauth2_server
 
-go 1.22
+go 1.24


### PR DESCRIPTION
## Summary
- bump the module to Go 1.24 and refresh documentation
- update the Dockerfile build stage to Go 1.24

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_690505a818e8832cba73df7c75ad8870