### PR TITLE
Use UUIDv4 for generated identity IDs

### DIFF
--- a/internal/random/id.go
+++ b/internal/random/id.go
@@ -5,11 +5,23 @@ import (
 	"encoding/hex"
 )
 
-// NewID returns a 128-bit random identifier encoded as hex.
+// NewID returns a version 4 UUID string.
 func NewID() string {
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		panic(err)
 	}
-	return hex.EncodeToString(b[:])
+
+	// Set version (4) and variant (10) bits per RFC 4122.
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	var dst [32]byte
+	hex.Encode(dst[:], b[:])
+
+	return string(dst[0:8]) + "-" +
+		string(dst[8:12]) + "-" +
+		string(dst[12:16]) + "-" +
+		string(dst[16:20]) + "-" +
+		string(dst[20:32])
 }


### PR DESCRIPTION
## Summary
- update the random ID generator to produce RFC 4122 version 4 UUIDs
- ensure the proper version and variant bits are set and format output with hyphens

## Testing
- GOTOOLCHAIN=local go test ./internal/random

------
https://chatgpt.com/codex/tasks/task_e_6905120ef65c832c999e60c55201e8ec