### PR TITLE
Add SQLite-backed client registry, admin CRUD API, and seed tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.24 AS build
 WORKDIR /app
 COPY go.mod ./
 RUN go mod download
+RUN apt-get update && apt-get install -y sqlite3 && rm -rf /var/lib/apt/lists/*
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /bin/as ./cmd/as
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /bin/rs ./cmd/rs || true
@@ -10,6 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /bin/rs ./cmd/rs || true
 FROM gcr.io/distroless/base-debian12
 COPY --from=build /bin/as /bin/as
 COPY --from=build /bin/rs /bin/rs
+COPY --from=build /usr/bin/sqlite3 /usr/bin/sqlite3
 EXPOSE 8080 9090
 USER 65532:65532
 CMD ["/bin/as"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run-as run-rs test test-exchange
+.PHONY: build run-as run-rs test test-exchange dev-up seed smoke
 
 build:
 	go build ./...
@@ -14,3 +14,12 @@ test:
 
 test-exchange:
 	AS_BASE=${AS_BASE:-http://localhost:8080} RS_BASE=${RS_BASE:-http://localhost:9090} ./scripts/test_obo.sh
+
+dev-up:
+	docker compose up --build
+
+seed:
+	./scripts/seed_clients.sh
+
+smoke:
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ The project is intended for local development and demo scenarios. Tokens are JSO
 |                      |           |                          |
 | • /register/human    |           | • /accounts/{id}/orders/ |
 | • /register/agent    |           |   export                 |
-| • /authorize         |           | • Validates JWT, perm,   |
-| • /token             |           |   authorization_details  |
+| • /oauth2/authorize  |           | • Validates JWT, perm,   |
+| • /oauth2/token      |           |   authorization_details  |
 | • /subject-assertion |           |                          |
+| • /admin/clients     |           |                          |
 +----------------------+           +--------------------------+
 ```
 
@@ -50,6 +51,7 @@ The project is intended for local development and demo scenarios. Tokens are JSO
 
 - Go **1.24+**
 - `curl`
+- `sqlite3` (or set `AS_CLIENT_STORE=memory`)
 - Optional: Docker & Docker Compose v2
 - Optional: `make`
 
@@ -87,7 +89,7 @@ Set additional environment variables by editing `docker-compose.yml` or creating
 
 ## Identity Registration & End-to-End OAuth/OBO with Registered Identities
 
-Every OAuth/OBO flow relies on registered identities. The built-in APIs store data in an in-memory, thread-safe data store. Optionally protect the registration endpoints by setting `ADMIN_TOKEN` and sending `X-Admin-Token` headers.
+Every OAuth/OBO flow relies on registered identities. The built-in APIs store data in an in-memory, thread-safe data store. Optionally protect the registration endpoints by setting `AS_ADMIN_TOKEN` (or `ADMIN_TOKEN`) and sending `X-Admin-Token` headers.
 
 ### 1. Run the services
 
@@ -108,7 +110,7 @@ curl -sS -X POST http://localhost:8080/register/human \
 # Create an agent (client_id must match your OAuth client)
 curl -sS -X POST http://localhost:8080/register/agent \
   -H 'Content-Type: application/json' \
-  -d '{"agent_id":"ingestor-42","name":"Data Ingestor","client_id":"client-xyz","capabilities":["orders:read","orders:export"],"tenant_id":"default"}' | jq .
+  -d '{"agent_id":"ingestor-42","name":"Data Ingestor","client_id":"agent-cli","capabilities":["orders:read","orders:export"],"tenant_id":"default"}' | jq .
 ```
 
 Optional administrative helpers:
@@ -118,20 +120,29 @@ curl -sS http://localhost:8080/humans | jq .
 curl -sS http://localhost:8080/agents | jq .
 ```
 
+### Admin client registry
+
+Client registrations are managed via the admin API bound to `127.0.0.1` (default `127.0.0.1:8082`). Set `AS_ADMIN_TOKEN` and include `Authorization: Bearer <token>` when calling:
+
+- `POST   /admin/clients`
+- `GET    /admin/clients`
+- `GET    /admin/clients/{client_id}`
+- `PUT    /admin/clients/{client_id}`
+- `DELETE /admin/clients/{client_id}`
+
 ### 3. Authorisation code flow
 
 ```bash
 # Launch the authorisation request (use either human_id or email)
-open "http://localhost:8080/authorize?response_type=code&client_id=client-xyz&redirect_uri=http://localhost:8081/cb&scope=openid&email=alice@example.com"
+open "http://localhost:8080/oauth2/authorize?response_type=code&client_id=human-web&redirect_uri=http://localhost:5555/callback&scope=tickets.read&email=alice@example.com"
 
 # Exchange the code for tokens
-curl -sS -X POST http://localhost:8080/token \
+curl -sS -X POST http://localhost:8080/oauth2/token \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -d 'grant_type=authorization_code' \
   -d 'code=<CODE_FROM_REDIRECT>' \
-  -d 'client_id=client-xyz' \
-  -d 'client_secret=secret-xyz' \
-  -d 'redirect_uri=http://localhost:8081/cb' | jq .
+  -d 'client_id=human-web' \
+  -d 'redirect_uri=http://localhost:5555/callback' | jq .
 ```
 
 The access token’s `sub` claim equals the registered human ID, and includes `email`, `name`, and `tenant_id` claims.
@@ -149,14 +160,14 @@ Subject assertions are short-lived JWTs (`iss = aud =` authorisation server) use
 ### 5. Perform RFC 8693 token exchange
 
 ```bash
-curl -sS -X POST http://localhost:8080/token \
+curl -sS -X POST http://localhost:8080/oauth2/token \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -d 'grant_type=urn:ietf:params:oauth:grant-type:token-exchange' \
   -d "subject_token=<SUBJECT_ASSERTION_OR_ACCESS_TOKEN>" \
   -d 'subject_token_type=urn:ietf:params:oauth:token-type:access_token' \
   -d 'audience=http://localhost:9090' \
-  -d 'client_id=client-xyz' \
-  -d 'client_secret=secret-xyz' \
+  -d 'client_id=agent-cli' \
+  -d 'client_secret=agent-cli-secret' \
   --data-urlencode 'authorization_details=[{"type":"agent-action","actions":["orders:export"],"constraints":{"resource_ids":["acct:abc"]}}]' | jq .
 ```
 
@@ -173,7 +184,7 @@ curl -sS -H "Authorization: Bearer <OBO_ACCESS_TOKEN>" \
 
 ### 7. Negative tests
 
-- Request `/authorize` without `human_id`/`email` → `400 invalid_request`.
+- Request `/oauth2/authorize` without `human_id`/`email` → `400 invalid_request`.
 - Perform token exchange with an unknown agent or mismatched `client_id` → `400 invalid_request`.
 - Request OBO permissions that the agent is not entitled to → `403 invalid_request` with `no permissions` message.
 
@@ -194,7 +205,7 @@ Bootstrap demo data by creating a JSON file and pointing `SEED_IDENTITIES_JSON` 
     {
       "agent_id": "ingestor-42",
       "name": "Data Ingestor",
-      "client_id": "client-xyz",
+      "client_id": "agent-cli",
       "capabilities": ["orders:read", "orders:export"],
       "tenant_id": "default"
     }
@@ -207,6 +218,18 @@ SEED_IDENTITIES_JSON=./data/seed.json go run ./cmd/as
 ```
 
 When using Docker Compose, mount the file and set the environment variable in `docker-compose.yml`.
+
+### Seeding clients
+
+Client registrations live in SQLite by default. Seed the demo clients with:
+
+```bash
+make seed
+# or
+AS_CLIENTS_DB=./data/clients.db ./scripts/seed_clients.sh
+```
+
+The seed files live in `clients/*.json`. Update those files (or add new ones) to register additional clients.
 
 ### Postman collection
 
@@ -248,7 +271,7 @@ Import the following collection and set the environment variables `BASE_URL`, `C
       "request": {
         "method": "POST",
         "header": [{"key": "Content-Type", "value": "application/x-www-form-urlencoded"}],
-        "url": "{{BASE_URL}}/token",
+        "url": "{{BASE_URL}}/oauth2/token",
         "body": {
           "mode": "urlencoded",
           "urlencoded": [
@@ -281,11 +304,13 @@ Unit tests cover validation logic, the in-memory identity store, HTTP handlers, 
 | ----------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------- |
 | `ISSUER`                      | Issuer used in all minted tokens                                                             | `http://localhost:8080`         |
 | `RS_AUDIENCE`                 | Audience for access and OBO tokens                                                           | `http://localhost:9090`         |
-| `ADMIN_TOKEN`                 | Optional shared secret that gates `/register/*` endpoints (`X-Admin-Token` header required) | unset                           |
+| `AS_ADMIN_TOKEN`              | Shared secret that gates `/register/*` (`X-Admin-Token`) and `/admin/*` (`Authorization: Bearer`) endpoints | unset          |
+| `ADMIN_TOKEN`                 | Legacy alias for `AS_ADMIN_TOKEN`                                                          | unset                           |
 | `ALLOW_LEGACY_HARDCODED`      | Set to `true` to allow legacy hard-coded users/agents (development only)                    | `false`                         |
 | `SEED_IDENTITIES_JSON`        | Path to a JSON file containing initial humans/agents (`{"humans":[],"agents":[]}`)       | unset                           |
-| `AS_DEFAULT_CLIENT_ID`        | Default OAuth client ID                                                                      | `client-xyz`                    |
-| `AS_DEFAULT_CLIENT_SECRET`    | Default OAuth client secret                                                                  | `secret-xyz`                    |
+| `AS_CLIENTS_DB`               | SQLite database path for client registrations                                               | `data/clients.db`               |
+| `AS_CLIENT_STORE`             | Client store driver (`sqlite` or `memory`)                                                  | `sqlite`                        |
+| `AS_ADMIN_ADDR`               | Bind address for the admin client registry API                                              | `127.0.0.1:8082`                |
 | `AS_SIGNING_KEY_BASE64`       | Base64-encoded HMAC signing key                                                              | `ZGV2LXNpZ25pbmcta2V5LTEyMzQ=`  |
 | `AS_SIGNING_KEY_ID`           | JWT header `kid`                                                                             | `dev-hs256`                     |
 | `AS_CODE_TTL_SECONDS`         | Authorisation code lifetime (seconds)                                                        | `120`                           |
@@ -310,4 +335,3 @@ internal/
   store/        # OAuth client/code/refresh stores and identity store implementations
 scripts/        # Automation helpers
 ```
-

--- a/clients/agent-cli.json
+++ b/clients/agent-cli.json
@@ -1,0 +1,14 @@
+{
+  "client_id": "agent-cli",
+  "client_type": "confidential",
+  "client_secret": "agent-cli-secret",
+  "grant_types": [
+    "token_exchange",
+    "client_credentials"
+  ],
+  "scopes": [
+    "tickets.read",
+    "tickets.write",
+    "refunds.create"
+  ]
+}

--- a/clients/human-web.json
+++ b/clients/human-web.json
@@ -1,0 +1,14 @@
+{
+  "client_id": "human-web",
+  "client_type": "public",
+  "redirect_uris": [
+    "http://localhost:5555/callback"
+  ],
+  "grant_types": [
+    "authorization_code",
+    "refresh_token"
+  ],
+  "scopes": [
+    "tickets.read"
+  ]
+}

--- a/cmd/as/main.go
+++ b/cmd/as/main.go
@@ -11,9 +11,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"go_oauth2_server/internal/admin"
 	"go_oauth2_server/internal/config"
 	"go_oauth2_server/internal/identity"
 	internaljwt "go_oauth2_server/internal/jwt"
@@ -21,6 +24,7 @@ import (
 	"go_oauth2_server/internal/random"
 	"go_oauth2_server/internal/store"
 	memstore "go_oauth2_server/internal/store/mem"
+	sqlstore "go_oauth2_server/internal/store/sqlite"
 )
 
 func main() {
@@ -31,16 +35,13 @@ func main() {
 		log.Fatalf("load config: %v", err)
 	}
 
-	defaultClient := store.Client{
-		ID:           cfg.DefaultClientID,
-		Secret:       cfg.DefaultClientSecret,
-		RedirectURI:  "http://localhost:8081/callback",
-		Audience:     cfg.Audience,
-		DefaultScope: "orders:export",
-	}
 	logConfiguration(cfg)
 
-	st := store.New(defaultClient)
+	st := store.New()
+	clientStore, err := buildClientStore(cfg)
+	if err != nil {
+		log.Fatalf("init client store: %v", err)
+	}
 
 	identityStore := memstore.New()
 	if cfg.SeedIdentitiesPath != "" {
@@ -58,6 +59,7 @@ func main() {
 	srv := &authorizationServer{
 		cfg:                cfg,
 		store:              st,
+		clients:            clientStore,
 		signer:             signer,
 		oboService:         oboService,
 		identities:         identityStore,
@@ -75,6 +77,8 @@ func main() {
 	mux.HandleFunc("/.well-known/jwks.json", methodHandler(http.MethodGet, srv.handleJWKS))
 	mux.HandleFunc("/authorize", methodHandler(http.MethodGet, srv.handleAuthorize))
 	mux.HandleFunc("/token", methodHandler(http.MethodPost, srv.handleToken))
+	mux.HandleFunc("/oauth2/authorize", methodHandler(http.MethodGet, srv.handleAuthorize))
+	mux.HandleFunc("/oauth2/token", methodHandler(http.MethodPost, srv.handleToken))
 	mux.HandleFunc("/mint-assertion", methodHandler(http.MethodPost, srv.handleSubjectAssertion))
 	mux.HandleFunc("/subject-assertion", methodHandler(http.MethodPost, srv.handleSubjectAssertion))
 	mux.HandleFunc("/register/human", methodHandler(http.MethodPost, identityHandler.CreateHuman))
@@ -107,6 +111,18 @@ func main() {
 		addr = v
 	}
 
+	adminHandler := admin.NewClientHandler(clientStore, cfg.AdminToken)
+	adminMux := http.NewServeMux()
+	adminMux.HandleFunc("/admin/clients", adminHandler.HandleClients)
+	adminMux.HandleFunc("/admin/clients/", adminHandler.HandleClient)
+
+	go func() {
+		log.Printf("Admin API listening on %s", cfg.AdminAddr)
+		if err := http.ListenAndServe(cfg.AdminAddr, loggingMiddleware(adminMux)); err != nil {
+			log.Fatalf("admin listen: %v", err)
+		}
+	}()
+
 	log.Printf("Authorization server listening on %s", addr)
 	if err := http.ListenAndServe(addr, loggingMiddleware(mux)); err != nil {
 		log.Fatalf("listen: %v", err)
@@ -116,6 +132,7 @@ func main() {
 type authorizationServer struct {
 	cfg                *config.Config
 	store              *store.Store
+	clients            store.ClientStore
 	signer             *internaljwt.Signer
 	oboService         *obo.Service
 	identities         identity.Store
@@ -253,20 +270,29 @@ func (s *authorizationServer) handleAuthorize(w http.ResponseWriter, r *http.Req
 		return
 	}
 	clientID := q.Get("client_id")
-	client, ok := s.store.GetClient(clientID)
+	client, ok, err := s.clients.GetClient(r.Context(), clientID)
+	if err != nil {
+		writeOAuthError(w, http.StatusInternalServerError, "server_error", "client lookup failed")
+		return
+	}
 	if !ok {
 		writeOAuthError(w, http.StatusBadRequest, "unauthorized_client", "unknown client")
 		return
 	}
-	redirectURI := q.Get("redirect_uri")
-	if client.RedirectURI == "" {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "redirect_uri required")
+	if !clientAllowsGrant(client, store.GrantAuthorizationCode) {
+		writeOAuthError(w, http.StatusBadRequest, "unauthorized_client", "authorization_code not allowed")
 		return
 	}
+	redirectURI := strings.TrimSpace(q.Get("redirect_uri"))
 	if redirectURI == "" {
-		redirectURI = client.RedirectURI
+		if len(client.RedirectURIs) == 1 {
+			redirectURI = client.RedirectURIs[0]
+		} else {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_request", "redirect_uri required")
+			return
+		}
 	}
-	if redirectURI != client.RedirectURI {
+	if !redirectURIMatch(client.RedirectURIs, redirectURI) {
 		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "redirect_uri mismatch")
 		return
 	}
@@ -287,7 +313,11 @@ func (s *authorizationServer) handleAuthorize(w http.ResponseWriter, r *http.Req
 	}
 	scope := q.Get("scope")
 	if scope == "" {
-		scope = client.DefaultScope
+		scope = strings.Join(client.Scopes, " ")
+	}
+	if !scopeSubsetList(scope, client.Scopes) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_scope", "requested scope not allowed")
+		return
 	}
 
 	code := random.NewID()
@@ -323,13 +353,12 @@ func (s *authorizationServer) handleToken(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	client, err := s.authenticateClient(r)
+	grantType := r.PostFormValue("grant_type")
+	client, err := s.authenticateClient(r, grantType)
 	if err != nil {
 		writeOAuthError(w, http.StatusUnauthorized, "invalid_client", err.Error())
 		return
 	}
-
-	grantType := r.PostFormValue("grant_type")
 	switch grantType {
 	case "authorization_code":
 		s.handleAuthorizationCodeGrant(w, r, client)
@@ -414,6 +443,10 @@ func (s *authorizationServer) handleAuthorizationCodeGrant(w http.ResponseWriter
 		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "redirect_uri mismatch")
 		return
 	}
+	if !scopeSubsetList(record.Scope, client.Scopes) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_scope", "requested scope not allowed")
+		return
+	}
 	human, err := s.lookupHumanByID(r.Context(), record.HumanID)
 	if err != nil {
 		status := http.StatusBadRequest
@@ -461,6 +494,10 @@ func (s *authorizationServer) handleRefreshTokenGrant(w http.ResponseWriter, r *
 		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "unknown refresh token")
 		return
 	}
+	if !scopeSubsetList(rt.Scope, client.Scopes) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_scope", "requested scope not allowed")
+		return
+	}
 	if time.Now().After(rt.ExpiresAt) {
 		s.store.DeleteRefreshToken(token)
 		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token expired")
@@ -491,7 +528,11 @@ func (s *authorizationServer) handleRefreshTokenGrant(w http.ResponseWriter, r *
 func (s *authorizationServer) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Request, client store.Client) {
 	scope := r.PostFormValue("scope")
 	if scope == "" {
-		scope = client.DefaultScope
+		scope = strings.Join(client.Scopes, " ")
+	}
+	if !scopeSubsetList(scope, client.Scopes) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_scope", "requested scope not allowed")
+		return
 	}
 	subject := "client:" + client.ID
 	access, expiresIn, err := s.signer.IssueAccess(r.Context(), subject, client.ID, scope)
@@ -525,6 +566,10 @@ func (s *authorizationServer) handleTokenExchange(w http.ResponseWriter, r *http
 		// OBO tokens target the resource server as expected.
 		audience = s.cfg.Audience
 	}
+	if len(client.Audiences) > 0 && !stringInList(client.Audiences, audience) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_target", "audience not allowed")
+		return
+	}
 
 	rarRaw := r.PostFormValue("authorization_details")
 	rar, err := obo.ParseRAR(rarRaw)
@@ -555,6 +600,10 @@ func (s *authorizationServer) handleTokenExchange(w http.ResponseWriter, r *http
 		return
 	}
 	requestedScope := strings.TrimSpace(r.PostFormValue("scope"))
+	if requestedScope != "" && !scopeSubsetList(requestedScope, client.Scopes) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_scope", "requested scope not allowed")
+		return
+	}
 	if requestedScope != "" {
 		if !scopeSubset(requestedScope, subjectClaims["scope"]) {
 			writeOAuthError(w, http.StatusBadRequest, "invalid_scope", "requested scope exceeds subject token scope")
@@ -634,7 +683,7 @@ func (s *authorizationServer) handleTokenExchange(w http.ResponseWriter, r *http
 	})
 }
 
-func (s *authorizationServer) authenticateClient(r *http.Request) (store.Client, error) {
+func (s *authorizationServer) authenticateClient(r *http.Request, grantType string) (store.Client, error) {
 	header := r.Header.Get("Authorization")
 	var clientID, clientSecret string
 	if header != "" && strings.HasPrefix(strings.ToLower(header), "basic ") {
@@ -656,12 +705,21 @@ func (s *authorizationServer) authenticateClient(r *http.Request) (store.Client,
 	if clientID == "" {
 		return store.Client{}, errors.New("client_id required")
 	}
-	client, ok := s.store.GetClient(clientID)
+	client, ok, err := s.clients.GetClient(r.Context(), clientID)
+	if err != nil {
+		return store.Client{}, errors.New("client lookup failed")
+	}
 	if !ok {
 		return store.Client{}, errors.New("unknown client")
 	}
-	if client.Secret != "" && client.Secret != clientSecret {
-		return store.Client{}, errors.New("invalid client secret")
+	normalizedGrant := store.NormalizeGrantType(grantType)
+	if normalizedGrant != "" && !clientAllowsGrant(client, normalizedGrant) {
+		return store.Client{}, errors.New("unauthorized client")
+	}
+	if client.Type == store.ClientTypeConfidential {
+		if clientSecret == "" || client.Secret != clientSecret {
+			return store.Client{}, errors.New("invalid client secret")
+		}
 	}
 	return client, nil
 }
@@ -739,18 +797,81 @@ func loadDotEnv() {
 }
 
 func logConfiguration(cfg *config.Config) {
-	log.Printf("config: issuer=%s audience=%s allow_legacy=%t admin_token_set=%t seed=%s default_client_id=%s default_client_secret=%s code_ttl=%s access_ttl=%s refresh_ttl=%s obo_ttl=%s", cfg.Issuer, cfg.Audience, cfg.AllowLegacy, cfg.AdminToken != "", cfg.SeedIdentitiesPath, cfg.DefaultClientID, maskSecret(cfg.DefaultClientSecret), cfg.CodeTTL, cfg.AccessTokenTTL, cfg.RefreshTokenTTL, cfg.OBOTokenTTL)
+	log.Printf("config: issuer=%s audience=%s allow_legacy=%t admin_token_set=%t seed=%s client_store=%s clients_db=%s admin_addr=%s code_ttl=%s access_ttl=%s refresh_ttl=%s obo_ttl=%s", cfg.Issuer, cfg.Audience, cfg.AllowLegacy, cfg.AdminToken != "", cfg.SeedIdentitiesPath, cfg.ClientStoreDriver, cfg.ClientDBPath, cfg.AdminAddr, cfg.CodeTTL, cfg.AccessTokenTTL, cfg.RefreshTokenTTL, cfg.OBOTokenTTL)
 }
 
-func maskSecret(secret string) string {
-	secret = strings.TrimSpace(secret)
-	if secret == "" {
-		return ""
+func buildClientStore(cfg *config.Config) (store.ClientStore, error) {
+	switch strings.ToLower(strings.TrimSpace(cfg.ClientStoreDriver)) {
+	case "memory", "mem", "in-memory":
+		return memstore.NewClientStore(), nil
+	case "sqlite", "":
+		if _, err := exec.LookPath("sqlite3"); err != nil {
+			return nil, fmt.Errorf("sqlite3 not found: %w", err)
+		}
+		if err := ensureDir(filepath.Dir(cfg.ClientDBPath)); err != nil {
+			return nil, err
+		}
+		return sqlstore.NewClientStore(cfg.ClientDBPath)
+	default:
+		return nil, fmt.Errorf("unsupported client store driver %q", cfg.ClientStoreDriver)
 	}
-	if len(secret) <= 4 {
-		return "****"
+}
+
+func ensureDir(path string) error {
+	if path == "." || path == "" {
+		return nil
 	}
-	return secret[:2] + strings.Repeat("*", len(secret)-4) + secret[len(secret)-2:]
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	return nil
+}
+
+func clientAllowsGrant(client store.Client, grantType string) bool {
+	for _, grant := range client.GrantTypes {
+		if grant == grantType {
+			return true
+		}
+	}
+	return false
+}
+
+func redirectURIMatch(allowed []string, requested string) bool {
+	for _, uri := range allowed {
+		if uri == requested {
+			return true
+		}
+	}
+	return false
+}
+
+func scopeSubsetList(requested string, allowed []string) bool {
+	req := strings.Fields(strings.TrimSpace(requested))
+	if len(req) == 0 {
+		return true
+	}
+	if len(allowed) == 0 {
+		return false
+	}
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, scope := range allowed {
+		allowedSet[scope] = struct{}{}
+	}
+	for _, scope := range req {
+		if _, ok := allowedSet[scope]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func stringInList(list []string, value string) bool {
+	for _, entry := range list {
+		if entry == value {
+			return true
+		}
+	}
+	return false
 }
 
 func scopeSubset(requested string, subjectScope any) bool {

--- a/cmd/as/main_test.go
+++ b/cmd/as/main_test.go
@@ -55,6 +55,11 @@ s8Db464pzs9t0Z/+RowMN8nMuwXoybwSJYCdm83GEevJoZ4av5gaJCvIEjGHNCul
 odOEQaR0ILGMQJZmpfvekDyK
 -----END PRIVATE KEY-----`
 
+const (
+	testClientID     = "client-xyz"
+	testClientSecret = "secret-xyz"
+)
+
 func TestAuthorizationCodeFlowWithRegisteredHuman(t *testing.T) {
 	ctx := context.Background()
 	idStore := memstore.New()
@@ -67,7 +72,7 @@ func TestAuthorizationCodeFlowWithRegisteredHuman(t *testing.T) {
 	defer server.Close()
 
 	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
-	authURL := fmt.Sprintf("%s/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s", server.URL, url.QueryEscape(srv.cfg.DefaultClientID), url.QueryEscape("http://localhost/callback"), url.QueryEscape(human.ID))
+	authURL := fmt.Sprintf("%s/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s", server.URL, url.QueryEscape(testClientID), url.QueryEscape("http://localhost/callback"), url.QueryEscape(human.ID))
 	resp, err := client.Get(authURL)
 	if err != nil {
 		t.Fatalf("authorize request: %v", err)
@@ -90,9 +95,9 @@ func TestAuthorizationCodeFlowWithRegisteredHuman(t *testing.T) {
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
 	form.Set("redirect_uri", "http://localhost/callback")
-	form.Set("client_id", srv.cfg.DefaultClientID)
-	form.Set("client_secret", srv.cfg.DefaultClientSecret)
-	req, err := http.NewRequest(http.MethodPost, server.URL+"/token", strings.NewReader(form.Encode()))
+	form.Set("client_id", testClientID)
+	form.Set("client_secret", testClientSecret)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/oauth2/token", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatalf("create token request: %v", err)
 	}
@@ -164,11 +169,11 @@ func TestTokenExchangeWithRegisteredIdentities(t *testing.T) {
 	form.Set("subject_token", subjectToken)
 	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
 	form.Set("audience", srv.cfg.Audience)
-	form.Set("client_id", srv.cfg.DefaultClientID)
-	form.Set("client_secret", srv.cfg.DefaultClientSecret)
+	form.Set("client_id", testClientID)
+	form.Set("client_secret", testClientSecret)
 	form.Set("authorization_details", authDetails)
 	form.Set("agent_id", agent.AgentID)
-	resp, err := http.PostForm(server.URL+"/token", form)
+	resp, err := http.PostForm(server.URL+"/oauth2/token", form)
 	if err != nil {
 		t.Fatalf("obo request: %v", err)
 	}
@@ -234,10 +239,10 @@ func TestTokenExchangeCapabilityDenied(t *testing.T) {
 	form.Set("subject_token", subjectToken)
 	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
 	form.Set("audience", srv.cfg.Audience)
-	form.Set("client_id", srv.cfg.DefaultClientID)
-	form.Set("client_secret", srv.cfg.DefaultClientSecret)
+	form.Set("client_id", testClientID)
+	form.Set("client_secret", testClientSecret)
 	form.Set("authorization_details", authDetails)
-	resp, err := http.PostForm(server.URL+"/token", form)
+	resp, err := http.PostForm(server.URL+"/oauth2/token", form)
 	if err != nil {
 		t.Fatalf("obo request: %v", err)
 	}
@@ -255,7 +260,7 @@ func TestTokenExchangeInvalidSubjectToken(t *testing.T) {
 		t.Fatalf("create human: %v", err)
 	}
 
-	srv, server := newTestServer(t, idStore)
+	_, server := newTestServer(t, idStore)
 	defer server.Close()
 
 	form := url.Values{}
@@ -263,10 +268,10 @@ func TestTokenExchangeInvalidSubjectToken(t *testing.T) {
 	form.Set("subject_token", "not-a-token")
 	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
 	form.Set("scope", "orders:export")
-	form.Set("client_id", srv.cfg.DefaultClientID)
-	form.Set("client_secret", srv.cfg.DefaultClientSecret)
+	form.Set("client_id", testClientID)
+	form.Set("client_secret", testClientSecret)
 
-	resp, err := http.PostForm(server.URL+"/token", form)
+	resp, err := http.PostForm(server.URL+"/oauth2/token", form)
 	if err != nil {
 		t.Fatalf("obo request: %v", err)
 	}
@@ -296,7 +301,7 @@ func TestRedirectURIMismatch(t *testing.T) {
 	defer server.Close()
 
 	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
-	authURL := fmt.Sprintf("%s/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s", server.URL, url.QueryEscape("client-xyz"), url.QueryEscape("http://localhost/other"), url.QueryEscape(human.ID))
+	authURL := fmt.Sprintf("%s/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s", server.URL, url.QueryEscape(testClientID), url.QueryEscape("http://localhost/other"), url.QueryEscape(human.ID))
 	resp, err := client.Get(authURL)
 	if err != nil {
 		t.Fatalf("authorize request: %v", err)
@@ -315,11 +320,11 @@ func TestAuthorizationCodeOneTimeUse(t *testing.T) {
 		t.Fatalf("create human: %v", err)
 	}
 
-	srv, server := newTestServer(t, idStore)
+	_, server := newTestServer(t, idStore)
 	defer server.Close()
 
 	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
-	authURL := fmt.Sprintf("%s/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s", server.URL, url.QueryEscape(srv.cfg.DefaultClientID), url.QueryEscape("http://localhost/callback"), url.QueryEscape(human.ID))
+	authURL := fmt.Sprintf("%s/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s", server.URL, url.QueryEscape(testClientID), url.QueryEscape("http://localhost/callback"), url.QueryEscape(human.ID))
 	resp, err := client.Get(authURL)
 	if err != nil {
 		t.Fatalf("authorize request: %v", err)
@@ -339,15 +344,15 @@ func TestAuthorizationCodeOneTimeUse(t *testing.T) {
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
 	form.Set("redirect_uri", "http://localhost/callback")
-	form.Set("client_id", srv.cfg.DefaultClientID)
-	form.Set("client_secret", srv.cfg.DefaultClientSecret)
-	resp, err = http.PostForm(server.URL+"/token", form)
+	form.Set("client_id", testClientID)
+	form.Set("client_secret", testClientSecret)
+	resp, err = http.PostForm(server.URL+"/oauth2/token", form)
 	if err != nil {
 		t.Fatalf("token request: %v", err)
 	}
 	resp.Body.Close()
 
-	resp, err = http.PostForm(server.URL+"/token", form)
+	resp, err = http.PostForm(server.URL+"/oauth2/token", form)
 	if err != nil {
 		t.Fatalf("second token request: %v", err)
 	}
@@ -366,22 +371,20 @@ func TestAuthorizationCodeExpires(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		Issuer:              "http://test-as",
-		Audience:            "http://test-rs",
-		SigningKeyPEM:       []byte(testSigningKeyPEM),
-		SigningKeyID:        "test-key",
-		DefaultClientID:     "client-xyz",
-		DefaultClientSecret: "secret-xyz",
-		CodeTTL:             10 * time.Millisecond,
-		AccessTokenTTL:      time.Hour,
-		RefreshTokenTTL:     time.Hour,
-		OBOTokenTTL:         time.Minute,
+		Issuer:          "http://test-as",
+		Audience:        "http://test-rs",
+		SigningKeyPEM:   []byte(testSigningKeyPEM),
+		SigningKeyID:    "test-key",
+		CodeTTL:         10 * time.Millisecond,
+		AccessTokenTTL:  time.Hour,
+		RefreshTokenTTL: time.Hour,
+		OBOTokenTTL:     time.Minute,
 	}
-	srv, server := newTestServerWithConfig(t, idStore, cfg)
+	_, server := newTestServerWithConfig(t, idStore, cfg)
 	defer server.Close()
 
 	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
-	authURL := fmt.Sprintf("%s/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s", server.URL, url.QueryEscape(srv.cfg.DefaultClientID), url.QueryEscape("http://localhost/callback"), url.QueryEscape(human.ID))
+	authURL := fmt.Sprintf("%s/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s", server.URL, url.QueryEscape(testClientID), url.QueryEscape("http://localhost/callback"), url.QueryEscape(human.ID))
 	resp, err := client.Get(authURL)
 	if err != nil {
 		t.Fatalf("authorize request: %v", err)
@@ -403,9 +406,9 @@ func TestAuthorizationCodeExpires(t *testing.T) {
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
 	form.Set("redirect_uri", "http://localhost/callback")
-	form.Set("client_id", srv.cfg.DefaultClientID)
-	form.Set("client_secret", srv.cfg.DefaultClientSecret)
-	resp, err = http.PostForm(server.URL+"/token", form)
+	form.Set("client_id", testClientID)
+	form.Set("client_secret", testClientSecret)
+	resp, err = http.PostForm(server.URL+"/oauth2/token", form)
 	if err != nil {
 		t.Fatalf("token request: %v", err)
 	}
@@ -427,10 +430,10 @@ func TestJWKSAndJWTClaims(t *testing.T) {
 
 	form := url.Values{}
 	form.Set("grant_type", "client_credentials")
-	form.Set("client_id", srv.cfg.DefaultClientID)
-	form.Set("client_secret", srv.cfg.DefaultClientSecret)
+	form.Set("client_id", testClientID)
+	form.Set("client_secret", testClientSecret)
 	form.Set("scope", "orders:export")
-	resp, err := http.PostForm(server.URL+"/token", form)
+	resp, err := http.PostForm(server.URL+"/oauth2/token", form)
 	if err != nil {
 		t.Fatalf("token request: %v", err)
 	}
@@ -494,7 +497,7 @@ func TestTokenExchangeScopeEscalationDenied(t *testing.T) {
 	defer server.Close()
 
 	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
-	authURL := fmt.Sprintf("%s/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=%s&human_id=%s", server.URL, url.QueryEscape(srv.cfg.DefaultClientID), url.QueryEscape("http://localhost/callback"), url.QueryEscape("orders:read"), url.QueryEscape(human.ID))
+	authURL := fmt.Sprintf("%s/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=%s&human_id=%s", server.URL, url.QueryEscape(testClientID), url.QueryEscape("http://localhost/callback"), url.QueryEscape("orders:read"), url.QueryEscape(human.ID))
 	resp, err := client.Get(authURL)
 	if err != nil {
 		t.Fatalf("authorize request: %v", err)
@@ -514,9 +517,9 @@ func TestTokenExchangeScopeEscalationDenied(t *testing.T) {
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
 	form.Set("redirect_uri", "http://localhost/callback")
-	form.Set("client_id", srv.cfg.DefaultClientID)
-	form.Set("client_secret", srv.cfg.DefaultClientSecret)
-	resp, err = http.PostForm(server.URL+"/token", form)
+	form.Set("client_id", testClientID)
+	form.Set("client_secret", testClientSecret)
+	resp, err = http.PostForm(server.URL+"/oauth2/token", form)
 	if err != nil {
 		t.Fatalf("token request: %v", err)
 	}
@@ -535,10 +538,10 @@ func TestTokenExchangeScopeEscalationDenied(t *testing.T) {
 	exchange.Set("subject_token", subjectToken)
 	exchange.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
 	exchange.Set("audience", srv.cfg.Audience)
-	exchange.Set("client_id", srv.cfg.DefaultClientID)
-	exchange.Set("client_secret", srv.cfg.DefaultClientSecret)
+	exchange.Set("client_id", testClientID)
+	exchange.Set("client_secret", testClientSecret)
 	exchange.Set("scope", "orders:export")
-	resp, err = http.PostForm(server.URL+"/token", exchange)
+	resp, err = http.PostForm(server.URL+"/oauth2/token", exchange)
 	if err != nil {
 		t.Fatalf("token exchange: %v", err)
 	}
@@ -552,29 +555,38 @@ func TestTokenExchangeScopeEscalationDenied(t *testing.T) {
 func newTestServer(t *testing.T, identityStore identity.Store) (*authorizationServer, *httptest.Server) {
 	t.Helper()
 	cfg := &config.Config{
-		Issuer:              "http://test-as",
-		Audience:            "http://test-rs",
-		SigningKeyPEM:       []byte(testSigningKeyPEM),
-		SigningKeyID:        "test-key",
-		DefaultClientID:     "client-xyz",
-		DefaultClientSecret: "secret-xyz",
-		CodeTTL:             time.Minute,
-		AccessTokenTTL:      time.Hour,
-		RefreshTokenTTL:     time.Hour,
-		OBOTokenTTL:         time.Minute,
+		Issuer:          "http://test-as",
+		Audience:        "http://test-rs",
+		SigningKeyPEM:   []byte(testSigningKeyPEM),
+		SigningKeyID:    "test-key",
+		CodeTTL:         time.Minute,
+		AccessTokenTTL:  time.Hour,
+		RefreshTokenTTL: time.Hour,
+		OBOTokenTTL:     time.Minute,
 	}
 	return newTestServerWithConfig(t, identityStore, cfg)
 }
 
 func newTestServerWithConfig(t *testing.T, identityStore identity.Store, cfg *config.Config) (*authorizationServer, *httptest.Server) {
-	defaultClient := store.Client{
-		ID:           cfg.DefaultClientID,
-		Secret:       cfg.DefaultClientSecret,
-		RedirectURI:  "http://localhost/callback",
-		Audience:     cfg.Audience,
-		DefaultScope: "openid",
+	oauthStore := store.New()
+	clientStore := memstore.NewClientStore()
+	_, err := clientStore.CreateClient(context.Background(), store.Client{
+		ID:           testClientID,
+		Type:         store.ClientTypeConfidential,
+		Secret:       testClientSecret,
+		RedirectURIs: []string{"http://localhost/callback"},
+		GrantTypes: []string{
+			store.GrantAuthorizationCode,
+			store.GrantRefreshToken,
+			store.GrantClientCredentials,
+			store.GrantTokenExchange,
+		},
+		Scopes:    []string{"openid", "orders:read", "orders:export"},
+		Audiences: []string{cfg.Audience},
+	})
+	if err != nil {
+		t.Fatalf("seed client: %v", err)
 	}
-	oauthStore := store.New(defaultClient)
 	signer, err := internaljwt.NewSigner(cfg.Issuer, cfg.Audience, cfg.SigningKeyPEM, cfg.SigningKeyID, cfg.AccessTokenTTL, cfg.RefreshTokenTTL, cfg.OBOTokenTTL)
 	if err != nil {
 		t.Fatalf("init signer: %v", err)
@@ -584,6 +596,7 @@ func newTestServerWithConfig(t *testing.T, identityStore identity.Store, cfg *co
 	srv := &authorizationServer{
 		cfg:                cfg,
 		store:              oauthStore,
+		clients:            clientStore,
 		signer:             signer,
 		oboService:         oboService,
 		identities:         identityStore,
@@ -597,6 +610,8 @@ func newTestServerWithConfig(t *testing.T, identityStore identity.Store, cfg *co
 	mux.HandleFunc("/.well-known/jwks.json", methodHandler(http.MethodGet, srv.handleJWKS))
 	mux.HandleFunc("/authorize", methodHandler(http.MethodGet, srv.handleAuthorize))
 	mux.HandleFunc("/token", methodHandler(http.MethodPost, srv.handleToken))
+	mux.HandleFunc("/oauth2/authorize", methodHandler(http.MethodGet, srv.handleAuthorize))
+	mux.HandleFunc("/oauth2/token", methodHandler(http.MethodPost, srv.handleToken))
 	mux.HandleFunc("/subject-assertion", methodHandler(http.MethodPost, srv.handleSubjectAssertion))
 	mux.HandleFunc("/register/human", methodHandler(http.MethodPost, identityHandler.CreateHuman))
 	mux.HandleFunc("/register/agent", methodHandler(http.MethodPost, identityHandler.CreateAgent))

--- a/cmd/seed-clients/main.go
+++ b/cmd/seed-clients/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"go_oauth2_server/internal/store"
+	sqlstore "go_oauth2_server/internal/store/sqlite"
+)
+
+func main() {
+	var (
+		dbPath = flag.String("db", os.Getenv("AS_CLIENTS_DB"), "sqlite db path")
+		dir    = flag.String("dir", "clients", "directory containing client json files")
+	)
+	flag.Parse()
+
+	if *dbPath == "" {
+		log.Fatal("db path required")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*dbPath), 0o755); err != nil {
+		log.Fatalf("ensure db dir: %v", err)
+	}
+
+	clientStore, err := sqlstore.NewClientStore(*dbPath)
+	if err != nil {
+		log.Fatalf("open store: %v", err)
+	}
+
+	entries, err := os.ReadDir(*dir)
+	if err != nil {
+		log.Fatalf("read dir: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(*dir, entry.Name())
+		if err := seedFile(context.Background(), clientStore, path); err != nil {
+			log.Fatalf("seed %s: %v", path, err)
+		}
+	}
+}
+
+func seedFile(ctx context.Context, clientStore store.ClientStore, path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	var input store.ClientInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return fmt.Errorf("parse: %w", err)
+	}
+	normalized, err := store.ValidateClientInput(input)
+	if err != nil {
+		return fmt.Errorf("validate: %w", err)
+	}
+	client := store.Client{
+		ID:           normalized.ClientID,
+		Type:         normalized.ClientType,
+		Secret:       normalized.ClientSecret,
+		RedirectURIs: normalized.RedirectURIs,
+		GrantTypes:   normalized.GrantTypes,
+		Scopes:       normalized.Scopes,
+		Audiences:    normalized.Audiences,
+	}
+	_, err = clientStore.CreateClient(ctx, client)
+	if err != nil {
+		if err == store.ErrClientExists {
+			log.Printf("client %s already exists, skipping", client.ID)
+			return nil
+		}
+		return err
+	}
+	log.Printf("seeded client: %s", client.ID)
+	return nil
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,13 @@ services:
     environment:
       - ISSUER=http://as:8080
       - RS_AUDIENCE=http://rs:9090
-      - ADMIN_TOKEN=
+      - AS_ADMIN_TOKEN=
       - ALLOW_LEGACY_HARDCODED=false
       - SEED_IDENTITIES_JSON=
+      - AS_CLIENTS_DB=/data/clients.db
+      - AS_ADMIN_ADDR=127.0.0.1:8082
       - AS_SIGNING_KEY_BASE64=ZGV2LXNpZ25pbmcta2V5LTEyMzQ=
       - AS_SIGNING_KEY_ID=dev-hs256
-      - AS_DEFAULT_CLIENT_ID=client-xyz
-      - AS_DEFAULT_CLIENT_SECRET=secret-xyz
     volumes:
       - ./data:/data
     ports:

--- a/internal/admin/clients.go
+++ b/internal/admin/clients.go
@@ -1,0 +1,213 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"go_oauth2_server/internal/store"
+)
+
+type ClientHandler struct {
+	store      store.ClientStore
+	adminToken string
+}
+
+func NewClientHandler(store store.ClientStore, adminToken string) *ClientHandler {
+	return &ClientHandler{store: store, adminToken: adminToken}
+}
+
+func (h *ClientHandler) HandleClients(w http.ResponseWriter, r *http.Request) {
+	if !h.authorize(w, r) {
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		h.listClients(w, r)
+	case http.MethodPost:
+		h.createClient(w, r)
+	default:
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": "method_not_allowed"})
+	}
+}
+
+func (h *ClientHandler) HandleClient(w http.ResponseWriter, r *http.Request) {
+	if !h.authorize(w, r) {
+		return
+	}
+	id := strings.TrimPrefix(r.URL.Path, "/admin/clients/")
+	id = strings.TrimSpace(id)
+	if id == "" {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": "client_not_found"})
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		h.getClient(w, r, id)
+	case http.MethodPut:
+		h.updateClient(w, r, id)
+	case http.MethodDelete:
+		h.deleteClient(w, r, id)
+	default:
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": "method_not_allowed"})
+	}
+}
+
+func (h *ClientHandler) listClients(w http.ResponseWriter, r *http.Request) {
+	clients, err := h.store.ListClients(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "list_failed"})
+		return
+	}
+	writeJSON(w, http.StatusOK, clients)
+}
+
+func (h *ClientHandler) createClient(w http.ResponseWriter, r *http.Request) {
+	var input store.ClientInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		return
+	}
+	normalized, err := store.ValidateClientInput(input)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	client := clientFromInput(normalized)
+	created, err := h.store.CreateClient(r.Context(), client)
+	if err != nil {
+		if errors.Is(err, store.ErrClientExists) {
+			writeJSON(w, http.StatusConflict, map[string]any{"error": "client_exists"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "create_failed"})
+		return
+	}
+	h.logChange("create", created)
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (h *ClientHandler) getClient(w http.ResponseWriter, r *http.Request, id string) {
+	client, ok, err := h.store.GetClient(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "get_failed"})
+		return
+	}
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": "client_not_found"})
+		return
+	}
+	writeJSON(w, http.StatusOK, client)
+}
+
+func (h *ClientHandler) updateClient(w http.ResponseWriter, r *http.Request, id string) {
+	var input store.ClientInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		return
+	}
+	if input.ClientID != "" && input.ClientID != id {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "client_id_mismatch"})
+		return
+	}
+	input.ClientID = id
+	normalized, err := store.ValidateClientInput(input)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	existing, ok, err := h.store.GetClient(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "get_failed"})
+		return
+	}
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": "client_not_found"})
+		return
+	}
+	client := clientFromInput(normalized)
+	client.CreatedAt = existing.CreatedAt
+	updated, err := h.store.UpdateClient(r.Context(), client)
+	if err != nil {
+		if errors.Is(err, store.ErrClientNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]any{"error": "client_not_found"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "update_failed"})
+		return
+	}
+	h.logChange("update", updated)
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (h *ClientHandler) deleteClient(w http.ResponseWriter, r *http.Request, id string) {
+	if err := h.store.DeleteClient(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrClientNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]any{"error": "client_not_found"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "delete_failed"})
+		return
+	}
+	h.logChange("delete", store.Client{ID: id})
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *ClientHandler) authorize(w http.ResponseWriter, r *http.Request) bool {
+	if h.adminToken == "" {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "admin_token_unset"})
+		return false
+	}
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	if auth == "" || !strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "missing_token"})
+		return false
+	}
+	token := strings.TrimSpace(auth[len("bearer "):])
+	if token != h.adminToken {
+		writeJSON(w, http.StatusForbidden, map[string]any{"error": "invalid_token"})
+		return false
+	}
+	return true
+}
+
+func (h *ClientHandler) logChange(action string, client store.Client) {
+	payload := map[string]any{
+		"event":       "admin_client_change",
+		"action":      action,
+		"client_id":   client.ID,
+		"client_type": client.Type,
+		"grant_types": client.GrantTypes,
+		"scopes":      client.Scopes,
+		"audiences":   client.Audiences,
+		"timestamp":   time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("admin change: %s", action)
+		return
+	}
+	log.Printf("%s", data)
+}
+
+func clientFromInput(input store.ClientInput) store.Client {
+	return store.Client{
+		ID:           input.ClientID,
+		Type:         input.ClientType,
+		Secret:       input.ClientSecret,
+		RedirectURIs: input.RedirectURIs,
+		GrantTypes:   input.GrantTypes,
+		Scopes:       input.Scopes,
+		Audiences:    input.Audiences,
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,35 +7,38 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"go_oauth2_server/internal/store"
 )
 
 // Config represents runtime configuration for the authorization server.
 type Config struct {
-	Issuer              string
-	Audience            string
-	SigningKeyPEM       []byte
-	SigningKeyID        string
-	DefaultClientID     string
-	DefaultClientSecret string
-	CodeTTL             time.Duration
-	AccessTokenTTL      time.Duration
-	RefreshTokenTTL     time.Duration
-	OBOTokenTTL         time.Duration
-	AdminToken          string
-	AllowLegacy         bool
-	SeedIdentitiesPath  string
+	Issuer             string
+	Audience           string
+	SigningKeyPEM      []byte
+	SigningKeyID       string
+	CodeTTL            time.Duration
+	AccessTokenTTL     time.Duration
+	RefreshTokenTTL    time.Duration
+	OBOTokenTTL        time.Duration
+	AdminToken         string
+	AllowLegacy        bool
+	SeedIdentitiesPath string
+	ClientDBPath       string
+	ClientStoreDriver  string
+	AdminAddr          string
 }
 
 const (
 	defaultIssuer         = "http://localhost:8080"
 	defaultAudience       = "http://localhost:9090"
-	defaultClientID       = "client-xyz"
-	defaultClientSecret   = "secret-xyz"
 	defaultSigningKeyID   = "dev-rs256"
 	defaultCodeTTLSeconds = 120
 	defaultAccessTTL      = 3600
 	defaultRefreshTTL     = 86400
 	defaultOBOTTL         = 900
+	defaultClientDBPath   = "data/clients.db"
+	defaultAdminAddr      = "127.0.0.1:8082"
 )
 
 const defaultSigningKeyPEM = `-----BEGIN PRIVATE KEY-----
@@ -70,13 +73,14 @@ odOEQaR0ILGMQJZmpfvekDyK
 // Load loads configuration from environment variables.
 func Load() (*Config, error) {
 	cfg := &Config{
-		Issuer:              firstNonEmpty(getEnv("ISSUER", ""), getEnv("AS_ISSUER", defaultIssuer)),
-		Audience:            firstNonEmpty(getEnv("RS_AUDIENCE", ""), getEnv("AS_AUDIENCE", defaultAudience)),
-		DefaultClientID:     getEnv("AS_DEFAULT_CLIENT_ID", defaultClientID),
-		DefaultClientSecret: getEnv("AS_DEFAULT_CLIENT_SECRET", defaultClientSecret),
-		SigningKeyID:        getEnv("AS_SIGNING_KEY_ID", defaultSigningKeyID),
-		AdminToken:          getEnv("ADMIN_TOKEN", ""),
-		SeedIdentitiesPath:  getEnv("SEED_IDENTITIES_JSON", ""),
+		Issuer:             firstNonEmpty(getEnv("ISSUER", ""), getEnv("AS_ISSUER", defaultIssuer)),
+		Audience:           firstNonEmpty(getEnv("RS_AUDIENCE", ""), getEnv("AS_AUDIENCE", defaultAudience)),
+		SigningKeyID:       getEnv("AS_SIGNING_KEY_ID", defaultSigningKeyID),
+		AdminToken:         firstNonEmpty(getEnv("AS_ADMIN_TOKEN", ""), getEnv("ADMIN_TOKEN", "")),
+		SeedIdentitiesPath: getEnv("SEED_IDENTITIES_JSON", ""),
+		ClientDBPath:       getEnv("AS_CLIENTS_DB", defaultClientDBPath),
+		ClientStoreDriver:  firstNonEmpty(getEnv("AS_CLIENT_STORE", ""), store.DefaultClientStoreDriver()),
+		AdminAddr:          getEnv("AS_ADMIN_ADDR", defaultAdminAddr),
 	}
 
 	signingKey, err := loadSigningKeyPEM()

--- a/internal/store/client.go
+++ b/internal/store/client.go
@@ -1,0 +1,39 @@
+package store
+
+import "time"
+
+const (
+	ClientTypePublic       = "public"
+	ClientTypeConfidential = "confidential"
+
+	GrantAuthorizationCode   = "authorization_code"
+	GrantRefreshToken        = "refresh_token"
+	GrantClientCredentials   = "client_credentials"
+	GrantTokenExchange       = "token_exchange"
+	GrantTokenExchangeURN    = "urn:ietf:params:oauth:grant-type:token-exchange"
+	defaultClientStoreDriver = "sqlite"
+)
+
+// Client represents an OAuth client registration.
+type Client struct {
+	ID           string    `json:"client_id"`
+	Type         string    `json:"client_type"`
+	Secret       string    `json:"client_secret,omitempty"`
+	RedirectURIs []string  `json:"redirect_uris"`
+	GrantTypes   []string  `json:"grant_types"`
+	Scopes       []string  `json:"scopes"`
+	Audiences    []string  `json:"audiences,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+func NormalizeGrantType(grantType string) string {
+	if grantType == GrantTokenExchangeURN {
+		return GrantTokenExchange
+	}
+	return grantType
+}
+
+func DefaultClientStoreDriver() string {
+	return defaultClientStoreDriver
+}

--- a/internal/store/client_input.go
+++ b/internal/store/client_input.go
@@ -1,0 +1,100 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrClientNotFound = errors.New("client not found")
+	ErrClientExists   = errors.New("client already exists")
+)
+
+type ClientInput struct {
+	ClientID     string   `json:"client_id"`
+	ClientType   string   `json:"client_type"`
+	ClientSecret string   `json:"client_secret"`
+	RedirectURIs []string `json:"redirect_uris"`
+	GrantTypes   []string `json:"grant_types"`
+	Scopes       []string `json:"scopes"`
+	Audiences    []string `json:"audiences"`
+}
+
+func ValidateClientInput(input ClientInput) (ClientInput, error) {
+	input.ClientID = strings.TrimSpace(input.ClientID)
+	if input.ClientID == "" {
+		return ClientInput{}, errors.New("client_id required")
+	}
+	input.ClientType = strings.ToLower(strings.TrimSpace(input.ClientType))
+	switch input.ClientType {
+	case ClientTypePublic, ClientTypeConfidential:
+	default:
+		return ClientInput{}, errors.New("client_type must be public or confidential")
+	}
+	input.ClientSecret = strings.TrimSpace(input.ClientSecret)
+	if input.ClientType == ClientTypeConfidential && input.ClientSecret == "" {
+		return ClientInput{}, errors.New("client_secret required for confidential clients")
+	}
+	if input.ClientType == ClientTypePublic {
+		input.ClientSecret = ""
+	}
+	input.RedirectURIs = normalizeList(input.RedirectURIs)
+	rawGrants := normalizeList(input.GrantTypes)
+	input.GrantTypes = make([]string, 0, len(rawGrants))
+	for _, grant := range rawGrants {
+		if NormalizeGrantType(grant) != grant {
+			grant = NormalizeGrantType(grant)
+		}
+		input.GrantTypes = append(input.GrantTypes, grant)
+	}
+	input.Scopes = normalizeList(input.Scopes)
+	input.Audiences = normalizeList(input.Audiences)
+	if len(input.GrantTypes) == 0 {
+		return ClientInput{}, errors.New("grant_types required")
+	}
+	for _, grant := range input.GrantTypes {
+		if !validGrantType(grant) {
+			return ClientInput{}, fmt.Errorf("unsupported grant_type %q", grant)
+		}
+	}
+	if contains(input.GrantTypes, GrantAuthorizationCode) && len(input.RedirectURIs) == 0 {
+		return ClientInput{}, errors.New("redirect_uris required for authorization_code")
+	}
+	return input, nil
+}
+
+func validGrantType(grant string) bool {
+	switch grant {
+	case GrantAuthorizationCode, GrantRefreshToken, GrantClientCredentials, GrantTokenExchange:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeList(values []string) []string {
+	unique := make(map[string]struct{})
+	var normalized []string
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := unique[value]; ok {
+			continue
+		}
+		unique[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	return normalized
+}
+
+func contains(list []string, value string) bool {
+	for _, entry := range list {
+		if entry == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/client_store.go
+++ b/internal/store/client_store.go
@@ -1,0 +1,11 @@
+package store
+
+import "context"
+
+type ClientStore interface {
+	CreateClient(ctx context.Context, client Client) (Client, error)
+	GetClient(ctx context.Context, id string) (Client, bool, error)
+	ListClients(ctx context.Context) ([]Client, error)
+	UpdateClient(ctx context.Context, client Client) (Client, error)
+	DeleteClient(ctx context.Context, id string) error
+}

--- a/internal/store/mem/client_store.go
+++ b/internal/store/mem/client_store.go
@@ -1,0 +1,73 @@
+package mem
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go_oauth2_server/internal/store"
+)
+
+type ClientStore struct {
+	mu      sync.Mutex
+	clients map[string]store.Client
+}
+
+func NewClientStore() *ClientStore {
+	return &ClientStore{
+		clients: make(map[string]store.Client),
+	}
+}
+
+func (s *ClientStore) CreateClient(_ context.Context, client store.Client) (store.Client, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.clients[client.ID]; exists {
+		return store.Client{}, store.ErrClientExists
+	}
+	now := time.Now().UTC()
+	if client.CreatedAt.IsZero() {
+		client.CreatedAt = now
+	}
+	client.UpdatedAt = now
+	s.clients[client.ID] = client
+	return client, nil
+}
+
+func (s *ClientStore) GetClient(_ context.Context, id string) (store.Client, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	client, ok := s.clients[id]
+	return client, ok, nil
+}
+
+func (s *ClientStore) ListClients(_ context.Context) ([]store.Client, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	clients := make([]store.Client, 0, len(s.clients))
+	for _, client := range s.clients {
+		clients = append(clients, client)
+	}
+	return clients, nil
+}
+
+func (s *ClientStore) UpdateClient(_ context.Context, client store.Client) (store.Client, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.clients[client.ID]; !exists {
+		return store.Client{}, store.ErrClientNotFound
+	}
+	client.UpdatedAt = time.Now().UTC()
+	s.clients[client.ID] = client
+	return client, nil
+}
+
+func (s *ClientStore) DeleteClient(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.clients[id]; !exists {
+		return store.ErrClientNotFound
+	}
+	delete(s.clients, id)
+	return nil
+}

--- a/internal/store/sqlite/client_store.go
+++ b/internal/store/sqlite/client_store.go
@@ -1,0 +1,271 @@
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"go_oauth2_server/internal/store"
+)
+
+type ClientStore struct {
+	path string
+}
+
+func NewClientStore(path string) (*ClientStore, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("client db path required")
+	}
+	store := &ClientStore{path: path}
+	if err := store.init(context.Background()); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *ClientStore) init(ctx context.Context) error {
+	schema := `CREATE TABLE IF NOT EXISTS clients (
+client_id TEXT PRIMARY KEY,
+client_type TEXT NOT NULL,
+client_secret TEXT,
+redirect_uris TEXT NOT NULL,
+grant_types TEXT NOT NULL,
+scopes TEXT NOT NULL,
+audiences TEXT,
+created_at TEXT NOT NULL,
+updated_at TEXT NOT NULL
+);`
+	_, err := s.exec(ctx, schema)
+	if err != nil {
+		return fmt.Errorf("init schema: %w", err)
+	}
+	return nil
+}
+
+func (s *ClientStore) CreateClient(ctx context.Context, client store.Client) (store.Client, error) {
+	now := time.Now().UTC()
+	if client.CreatedAt.IsZero() {
+		client.CreatedAt = now
+	}
+	client.UpdatedAt = now
+	payload, err := encodeClient(client)
+	if err != nil {
+		return store.Client{}, err
+	}
+	sql := fmt.Sprintf(
+		"INSERT INTO clients (client_id, client_type, client_secret, redirect_uris, grant_types, scopes, audiences, created_at, updated_at) VALUES ('%s','%s','%s','%s','%s','%s','%s','%s','%s');",
+		sqlQuote(client.ID),
+		sqlQuote(client.Type),
+		sqlQuote(client.Secret),
+		sqlQuote(payload.redirectURIs),
+		sqlQuote(payload.grantTypes),
+		sqlQuote(payload.scopes),
+		sqlQuote(payload.audiences),
+		sqlQuote(client.CreatedAt.Format(time.RFC3339Nano)),
+		sqlQuote(client.UpdatedAt.Format(time.RFC3339Nano)),
+	)
+	_, err = s.exec(ctx, sql)
+	if err != nil {
+		if isConstraintError(err) {
+			return store.Client{}, store.ErrClientExists
+		}
+		return store.Client{}, fmt.Errorf("insert client: %w", err)
+	}
+	return client, nil
+}
+
+func (s *ClientStore) GetClient(ctx context.Context, id string) (store.Client, bool, error) {
+	sql := fmt.Sprintf("SELECT client_id, client_type, client_secret, redirect_uris, grant_types, scopes, audiences, created_at, updated_at FROM clients WHERE client_id = '%s';", sqlQuote(id))
+	clients, err := s.queryClients(ctx, sql)
+	if err != nil {
+		return store.Client{}, false, err
+	}
+	if len(clients) == 0 {
+		return store.Client{}, false, nil
+	}
+	return clients[0], true, nil
+}
+
+func (s *ClientStore) ListClients(ctx context.Context) ([]store.Client, error) {
+	sql := "SELECT client_id, client_type, client_secret, redirect_uris, grant_types, scopes, audiences, created_at, updated_at FROM clients ORDER BY client_id;"
+	return s.queryClients(ctx, sql)
+}
+
+func (s *ClientStore) UpdateClient(ctx context.Context, client store.Client) (store.Client, error) {
+	_, ok, err := s.GetClient(ctx, client.ID)
+	if err != nil {
+		return store.Client{}, err
+	}
+	if !ok {
+		return store.Client{}, store.ErrClientNotFound
+	}
+	client.UpdatedAt = time.Now().UTC()
+	payload, err := encodeClient(client)
+	if err != nil {
+		return store.Client{}, err
+	}
+	sql := fmt.Sprintf(
+		"UPDATE clients SET client_type='%s', client_secret='%s', redirect_uris='%s', grant_types='%s', scopes='%s', audiences='%s', updated_at='%s' WHERE client_id = '%s';",
+		sqlQuote(client.Type),
+		sqlQuote(client.Secret),
+		sqlQuote(payload.redirectURIs),
+		sqlQuote(payload.grantTypes),
+		sqlQuote(payload.scopes),
+		sqlQuote(payload.audiences),
+		sqlQuote(client.UpdatedAt.Format(time.RFC3339Nano)),
+		sqlQuote(client.ID),
+	)
+	_, err = s.exec(ctx, sql)
+	if err != nil {
+		return store.Client{}, fmt.Errorf("update client: %w", err)
+	}
+	return client, nil
+}
+
+func (s *ClientStore) DeleteClient(ctx context.Context, id string) error {
+	_, ok, err := s.GetClient(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return store.ErrClientNotFound
+	}
+	sql := fmt.Sprintf("DELETE FROM clients WHERE client_id = '%s';", sqlQuote(id))
+	_, err = s.exec(ctx, sql)
+	if err != nil {
+		return fmt.Errorf("delete client: %w", err)
+	}
+	return nil
+}
+
+type clientPayload struct {
+	redirectURIs string
+	grantTypes   string
+	scopes       string
+	audiences    string
+}
+
+func encodeClient(client store.Client) (clientPayload, error) {
+	redirectURIs, err := json.Marshal(client.RedirectURIs)
+	if err != nil {
+		return clientPayload{}, fmt.Errorf("encode redirect_uris: %w", err)
+	}
+	grantTypes, err := json.Marshal(client.GrantTypes)
+	if err != nil {
+		return clientPayload{}, fmt.Errorf("encode grant_types: %w", err)
+	}
+	scopes, err := json.Marshal(client.Scopes)
+	if err != nil {
+		return clientPayload{}, fmt.Errorf("encode scopes: %w", err)
+	}
+	audiences, err := json.Marshal(client.Audiences)
+	if err != nil {
+		return clientPayload{}, fmt.Errorf("encode audiences: %w", err)
+	}
+	return clientPayload{
+		redirectURIs: string(redirectURIs),
+		grantTypes:   string(grantTypes),
+		scopes:       string(scopes),
+		audiences:    string(audiences),
+	}, nil
+}
+
+func (s *ClientStore) queryClients(ctx context.Context, sql string) ([]store.Client, error) {
+	output, err := s.execJSON(ctx, sql)
+	if err != nil {
+		return nil, err
+	}
+	if len(output) == 0 {
+		return nil, nil
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(output, &rows); err != nil {
+		return nil, fmt.Errorf("decode rows: %w", err)
+	}
+	clients := make([]store.Client, 0, len(rows))
+	for _, row := range rows {
+		client, err := decodeRow(row)
+		if err != nil {
+			return nil, err
+		}
+		clients = append(clients, client)
+	}
+	return clients, nil
+}
+
+func decodeRow(row map[string]any) (store.Client, error) {
+	client := store.Client{
+		ID:   asString(row["client_id"]),
+		Type: asString(row["client_type"]),
+	}
+	client.Secret = asString(row["client_secret"])
+	if err := json.Unmarshal([]byte(asString(row["redirect_uris"])), &client.RedirectURIs); err != nil {
+		return store.Client{}, fmt.Errorf("decode redirect_uris: %w", err)
+	}
+	if err := json.Unmarshal([]byte(asString(row["grant_types"])), &client.GrantTypes); err != nil {
+		return store.Client{}, fmt.Errorf("decode grant_types: %w", err)
+	}
+	if err := json.Unmarshal([]byte(asString(row["scopes"])), &client.Scopes); err != nil {
+		return store.Client{}, fmt.Errorf("decode scopes: %w", err)
+	}
+	audiencesRaw := asString(row["audiences"])
+	if audiencesRaw != "" {
+		if err := json.Unmarshal([]byte(audiencesRaw), &client.Audiences); err != nil {
+			return store.Client{}, fmt.Errorf("decode audiences: %w", err)
+		}
+	}
+	var err error
+	client.CreatedAt, err = time.Parse(time.RFC3339Nano, asString(row["created_at"]))
+	if err != nil {
+		return store.Client{}, fmt.Errorf("parse created_at: %w", err)
+	}
+	client.UpdatedAt, err = time.Parse(time.RFC3339Nano, asString(row["updated_at"]))
+	if err != nil {
+		return store.Client{}, fmt.Errorf("parse updated_at: %w", err)
+	}
+	return client, nil
+}
+
+func (s *ClientStore) exec(ctx context.Context, sql string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "sqlite3", s.path, sql)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("sqlite3 exec: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return output, nil
+}
+
+func (s *ClientStore) execJSON(ctx context.Context, sql string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "sqlite3", "-json", s.path, sql)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("sqlite3 query: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return output, nil
+}
+
+func sqlQuote(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
+}
+
+func asString(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func isConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "UNIQUE constraint failed")
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6,57 +6,38 @@ import (
 	"time"
 )
 
-// Client represents an OAuth client registration.
-type Client struct {
-	ID           string
-	Secret       string
-	RedirectURI  string
-	Audience     string
-	DefaultScope string
-}
-
 // AuthorizationCode represents an authorization code grant.
 type AuthorizationCode struct {
-        Code        string
-        ClientID    string
-        HumanID     string
-        RedirectURI string
-        Scope       string
-        ExpiresAt   time.Time
+	Code        string
+	ClientID    string
+	HumanID     string
+	RedirectURI string
+	Scope       string
+	ExpiresAt   time.Time
 }
 
 // RefreshToken represents a refresh token record.
 type RefreshToken struct {
-        Token     string
-        ClientID  string
-        HumanID   string
-        Scope     string
-        ExpiresAt time.Time
+	Token     string
+	ClientID  string
+	HumanID   string
+	Scope     string
+	ExpiresAt time.Time
 }
 
 // Store is an in-memory data store for demo purposes.
 type Store struct {
 	mu            sync.Mutex
-	clients       map[string]Client
 	codes         map[string]AuthorizationCode
 	refreshTokens map[string]RefreshToken
 }
 
-// New creates a new Store with default data.
-func New(defaultClient Client) *Store {
+// New creates a new Store.
+func New() *Store {
 	return &Store{
-		clients:       map[string]Client{defaultClient.ID: defaultClient},
 		codes:         make(map[string]AuthorizationCode),
 		refreshTokens: make(map[string]RefreshToken),
 	}
-}
-
-// GetClient returns a client by ID.
-func (s *Store) GetClient(id string) (Client, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	client, ok := s.clients[id]
-	return client, ok
 }
 
 // SaveCode stores an authorization code.

--- a/scripts/seed_clients.sh
+++ b/scripts/seed_clients.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLIENTS_DIR="${CLIENTS_DIR:-${ROOT_DIR}/clients}"
+AS_CLIENTS_DB="${AS_CLIENTS_DB:-${ROOT_DIR}/data/clients.db}"
+
+mkdir -p "$(dirname "${AS_CLIENTS_DB}")"
+
+go run ./cmd/seed-clients -db "${AS_CLIENTS_DB}" -dir "${CLIENTS_DIR}"

--- a/scripts/test_obo.sh
+++ b/scripts/test_obo.sh
@@ -3,18 +3,20 @@ set -euo pipefail
 
 AS_BASE=${AS_BASE:-http://localhost:8080}
 RS_BASE=${RS_BASE:-http://localhost:9090}
-CLIENT_ID=${AS_DEFAULT_CLIENT_ID:-client-xyz}
-CLIENT_SECRET=${AS_DEFAULT_CLIENT_SECRET:-secret-xyz}
-REDIRECT_URI=${REDIRECT_URI:-http://localhost:8081/callback}
+HUMAN_CLIENT_ID=${HUMAN_CLIENT_ID:-human-web}
+AGENT_CLIENT_ID=${AGENT_CLIENT_ID:-agent-cli}
+AGENT_CLIENT_SECRET=${AGENT_CLIENT_SECRET:-agent-cli-secret}
+REDIRECT_URI=${REDIRECT_URI:-http://localhost:5555/callback}
 USER_ID=${USER_ID:-user:123}
 ACCOUNT_ID=${ACCOUNT_ID:-acct:abc}
 
 printf "[1/4] Requesting authorization code...\n" >&2
-AUTH_RES=$(curl -si -G -H "X-Demo-User: ${USER_ID}" "${AS_BASE}/authorize" \
+AUTH_RES=$(curl -si -G "${AS_BASE}/oauth2/authorize" \
   --data-urlencode "response_type=code" \
-  --data-urlencode "client_id=${CLIENT_ID}" \
+  --data-urlencode "client_id=${HUMAN_CLIENT_ID}" \
   --data-urlencode "redirect_uri=${REDIRECT_URI}" \
-  --data-urlencode "scope=orders:export" \
+  --data-urlencode "scope=tickets.read" \
+  --data-urlencode "human_id=${USER_ID}" \
   --data-urlencode "state=test")
 CODE=$(AUTH_RES="$AUTH_RES" python - <<'PY'
 import os
@@ -37,18 +39,18 @@ PY
 )
 
 printf "[2/4] Exchanging code for user token...\n" >&2
-TOKEN_JSON=$(curl -s -X POST "${AS_BASE}/token" \
-  -u "${CLIENT_ID}:${CLIENT_SECRET}" \
+TOKEN_JSON=$(curl -s -X POST "${AS_BASE}/oauth2/token" \
+  -u "${HUMAN_CLIENT_ID}:" \
   -d "grant_type=authorization_code" \
   --data-urlencode "code=${CODE}" \
   --data-urlencode "redirect_uri=${REDIRECT_URI}")
 USER_TOKEN=$(printf '%s' "$TOKEN_JSON" | python -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
 
 printf "[3/4] Minting actor assertion and performing token exchange...\n" >&2
-ACTOR_ASSERTION=$(go run ./tools/mint_assertion -actor agent:ingestor-42 -client "${CLIENT_ID}")
+ACTOR_ASSERTION=$(go run ./tools/mint_assertion -actor agent:ingestor-42 -client "${AGENT_CLIENT_ID}")
 RAR='[{"type":"agent-action","locations":["'"${RS_BASE}"'"],"actions":["orders:export"],"constraints":{"resource_ids":["'"${ACCOUNT_ID}"'"],"time_limit_sec":900,"max_records":1000,"purpose":"customer_export"}}]'
-OBO_JSON=$(curl -s -X POST "${AS_BASE}/token" \
-  -u "${CLIENT_ID}:${CLIENT_SECRET}" \
+OBO_JSON=$(curl -s -X POST "${AS_BASE}/oauth2/token" \
+  -u "${AGENT_CLIENT_ID}:${AGENT_CLIENT_SECRET}" \
   -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
   --data-urlencode "subject_token=${USER_TOKEN}" \
   -d "subject_token_type=urn:ietf:params:oauth:token-type:access_token" \


### PR DESCRIPTION
### Motivation
- Introduce a simple dynamic client registry (not full OIDC DCR) to manage OAuth clients outside of hard-coded defaults so clients can be created, updated, and validated at runtime. 
- Provide repeatable storage (SQLite) but keep a pluggable interface and in-memory implementation for tests and lightweight runs. 
- Expose a small admin API bound to loopback for CRUD operations and wire client checks into existing OAuth flows to enforce redirect URIs, grant types, scopes and audience constraints. 

### Description
- Add a `Client` model and validation (`internal/store/client.go`, `internal/store/client_input.go`) and a `ClientStore` interface (`internal/store/client_store.go`) with two implementations: in-memory (`internal/store/mem/client_store.go`) and SQLite-backed (`internal/store/sqlite/client_store.go`) that uses the `sqlite3` CLI for portability. 
- Implement admin HTTP handlers for CRUD on `/admin/clients` with `Authorization: Bearer <AS_ADMIN_TOKEN>` protection, structured JSON change logging, and bind the admin server to a loopback address configurable by `AS_ADMIN_ADDR` (`internal/admin/clients.go`, `cmd/as/main.go`, `internal/config/config.go`). 
- Wire the client registry into the authorization server by loading clients from the chosen `AS_CLIENT_STORE` and `AS_CLIENTS_DB`, adding `/oauth2/authorize` and `/oauth2/token` routes (aliases for existing endpoints), and enforcing exact `redirect_uri` matches, allowed `grant_types`, confidential client authentication, scope subset checks, and audience restrictions in token exchange flows (`cmd/as/main.go`). 
- Add seed tooling and assets: `cmd/seed-clients` helper, `scripts/seed_clients.sh`, demo client JSON files `clients/human-web.json` and `clients/agent-cli.json`, Make targets `dev-up`, `seed`, and `smoke`, updates to `scripts/test_obo.sh`, Dockerfile to include `sqlite3`, and README documentation about admin API, seeding, and new env vars (`AS_ADMIN_TOKEN`, `AS_CLIENTS_DB`, `AS_CLIENT_STORE`, `AS_ADMIN_ADDR`). 

### Testing
- Ran the full unit/integration suite with `go test ./...` and all packages completed successfully. 
- Added/updated `cmd/as` httptest-based tests to exercise the registry integration and they passed as part of `go test ./...`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ef4f3804832c9c8c65fd0a0ac4f4)