### PR TITLE
Harden OAuth flows: PKCE, refresh rotation, JWKS keyset, introspect/revoke, and rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ An educational OAuth 2.0 authorisation server and companion resource server writ
 - Rich authorisation requests (`authorization_details`) with permission hashing.
 - Identity registration APIs for both humans and agents that drive every OAuth/OBO flow.
 
-The project is intended for local development and demo scenarios. Tokens are JSON Web Tokens (JWTs) signed with a symmetric key; the resource server verifies them using the shared key and a published JWKS endpoint.
+The project is intended for local development and demo scenarios. Tokens are JSON Web Tokens (JWTs) signed with RSA keys; the resource server verifies them using the same key material and a published JWKS endpoint.
 
 ## Contents
 
 - [Architecture](#architecture)
+- [Production Readiness](#production-readiness)
 - [Prerequisites](#prerequisites)
 - [Running locally](#running-locally)
 - [Running with Docker Compose](#running-with-docker-compose)
@@ -47,6 +48,23 @@ The project is intended for local development and demo scenarios. Tokens are JSO
 - **Authorization Server** – owns human and agent registrations, issues authorisation codes, access tokens, refresh tokens, subject assertions, and OBO tokens. All flows resolve identities from the in-memory identity store.
 - **Resource Server** – a tiny API that expects an OBO access token. It verifies the signature, audience, issuer, human subject, actor information, `perm` claim, and `authorization_details` payload.
 
+## Production Readiness
+
+This project started as a lab. The following hardening has been added to help move toward production readiness without a major refactor:
+
+- **Authorization code hardening:** exact redirect URI matching, PKCE (S256) required for public clients, and one-time authorization code use with TTLs.
+- **Refresh token safety:** refresh token rotation with reuse detection (reuse revokes the entire family).
+- **Key management:** RSA keys with `kid` and JWKS publication; optional multi-key JWKS for overlap during rotation.
+- **Rate limiting:** configurable token bucket limits for `/oauth2/authorize`, `/oauth2/token`, `/oauth2/introspect`, and `/admin/*`.
+- **Introspection and revocation:** `/oauth2/introspect` and `/oauth2/revoke` supported for refresh tokens (access token revocation is not supported in-memory).
+
+**Still not production complete:**
+
+- No OIDC discovery or ID token support.
+- Access token revocation is not persisted or enforced (JWTs are self-contained).
+- HA/statelessness requires moving codes/refresh tokens to shared storage.
+- Metrics and structured audit logs are minimal; see `docs/PROD_READINESS_PLAN.md`.
+
 ## Prerequisites
 
 - Go **1.24+**
@@ -68,7 +86,6 @@ go run ./cmd/as
 
 # In another terminal start the resource server (RS)
 RS_AUDIENCE=http://localhost:9090 \
-AS_JWKS_URL=http://localhost:8080/.well-known/jwks.json \
 go run ./cmd/rs
 ```
 
@@ -166,8 +183,12 @@ High-level steps:
 3. Exchange the code at `/oauth2/token` for access/refresh tokens.
 
 ```bash
+# Generate a PKCE verifier/challenge for public clients
+CODE_VERIFIER=$(openssl rand -base64 32 | tr -d '=+/')
+CODE_CHALLENGE=$(printf '%s' "${CODE_VERIFIER}" | openssl dgst -sha256 -binary | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+
 # Launch the authorisation request (use either human_id or email)
-open "http://localhost:8080/oauth2/authorize?response_type=code&client_id=human-web&redirect_uri=http://localhost:5555/callback&scope=tickets.read&email=alice@example.com"
+open "http://localhost:8080/oauth2/authorize?response_type=code&client_id=human-web&redirect_uri=http://localhost:5555/callback&scope=tickets.read&email=alice@example.com&code_challenge=${CODE_CHALLENGE}&code_challenge_method=S256"
 
 # Exchange the code for tokens
 curl -sS -X POST http://localhost:8080/oauth2/token \
@@ -175,6 +196,7 @@ curl -sS -X POST http://localhost:8080/oauth2/token \
   -d 'grant_type=authorization_code' \
   -d 'code=<CODE_FROM_REDIRECT>' \
   -d 'client_id=human-web' \
+  -d "code_verifier=${CODE_VERIFIER}" \
   -d 'redirect_uri=http://localhost:5555/callback' | jq .
 ```
 
@@ -345,23 +367,34 @@ Unit tests cover validation logic, the in-memory identity store, HTTP handlers, 
 
 ## Configuration
 
-| Environment variable          | Description                                                                                  | Default                         |
-| ----------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------- |
-| `ISSUER`                      | Issuer used in all minted tokens                                                             | `http://localhost:8080`         |
-| `RS_AUDIENCE`                 | Audience for access and OBO tokens                                                           | `http://localhost:9090`         |
-| `AS_ADMIN_TOKEN`              | Shared secret that gates `/register/*` (`X-Admin-Token`) and `/admin/*` (`Authorization: Bearer`) endpoints | unset          |
-| `ADMIN_TOKEN`                 | Legacy alias for `AS_ADMIN_TOKEN`                                                          | unset                           |
-| `ALLOW_LEGACY_HARDCODED`      | Set to `true` to allow legacy hard-coded users/agents (development only)                    | `false`                         |
-| `SEED_IDENTITIES_JSON`        | Path to a JSON file containing initial humans/agents (`{"humans":[],"agents":[]}`)       | unset                           |
-| `AS_CLIENTS_DB`               | SQLite database path for client registrations                                               | `data/clients.db`               |
-| `AS_CLIENT_STORE`             | Client store driver (`sqlite` or `memory`)                                                  | `sqlite`                        |
-| `AS_ADMIN_ADDR`               | Bind address for the admin client registry API                                              | `127.0.0.1:8082`                |
-| `AS_SIGNING_KEY_BASE64`       | Base64-encoded HMAC signing key                                                              | `ZGV2LXNpZ25pbmcta2V5LTEyMzQ=`  |
-| `AS_SIGNING_KEY_ID`           | JWT header `kid`                                                                             | `dev-hs256`                     |
-| `AS_CODE_TTL_SECONDS`         | Authorisation code lifetime (seconds)                                                        | `120`                           |
-| `AS_ACCESS_TOKEN_TTL_SECONDS` | Access token lifetime (seconds)                                                              | `3600`                          |
-| `AS_REFRESH_TOKEN_TTL_SECONDS`| Refresh token lifetime (seconds)                                                             | `86400`                         |
-| `AS_OBO_TOKEN_TTL_SECONDS`    | OBO token lifetime (seconds)                                                                 | `900`                           |
+| Environment variable               | Description                                                                                  | Default                         |
+| ---------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------- |
+| `ISSUER`                           | Issuer used in all minted tokens                                                             | `http://localhost:8080`         |
+| `RS_AUDIENCE`                      | Audience for access and OBO tokens                                                           | `http://localhost:9090`         |
+| `AS_ADMIN_TOKEN`                   | Shared secret that gates `/register/*` (`X-Admin-Token`) and `/admin/*` (`Authorization: Bearer`) endpoints | unset          |
+| `ADMIN_TOKEN`                      | Legacy alias for `AS_ADMIN_TOKEN`                                                            | unset                           |
+| `ALLOW_LEGACY_HARDCODED`           | Set to `true` to allow legacy hard-coded users/agents (development only)                    | `false`                         |
+| `SEED_IDENTITIES_JSON`             | Path to a JSON file containing initial humans/agents (`{"humans":[],"agents":[]}`)           | unset                           |
+| `AS_CLIENTS_DB`                    | SQLite database path for client registrations                                               | `data/clients.db`               |
+| `AS_CLIENT_STORE`                  | Client store driver (`sqlite` or `memory`)                                                  | `sqlite`                        |
+| `AS_ADMIN_ADDR`                    | Bind address for the admin client registry API                                              | `127.0.0.1:8082`                |
+| `AS_SIGNING_KEY_PEM`               | RSA private key PEM (single key fallback)                                                   | embedded dev key                |
+| `AS_SIGNING_KEY_PATH`              | Path to RSA private key PEM                                                                  | unset                           |
+| `AS_SIGNING_KEYS_DIR`              | Directory of RSA private keys (filename base = `kid`)                                        | unset                           |
+| `AS_SIGNING_KEY_ID`                | Active JWT header `kid` (when using `AS_SIGNING_KEYS_DIR`)                                   | `dev-rs256`                     |
+| `AS_SIGNING_KEY_ROTATION_SECONDS`  | Interval to reload keys from `AS_SIGNING_KEYS_DIR` (0 disables)                              | `0`                             |
+| `AS_CODE_TTL_SECONDS`              | Authorisation code lifetime (seconds)                                                       | `120`                           |
+| `AS_ACCESS_TOKEN_TTL_SECONDS`      | Access token lifetime (seconds)                                                             | `3600`                          |
+| `AS_REFRESH_TOKEN_TTL_SECONDS`     | Refresh token lifetime (seconds)                                                            | `86400`                         |
+| `AS_OBO_TOKEN_TTL_SECONDS`         | OBO token lifetime (seconds)                                                                | `900`                           |
+| `AS_RATE_LIMIT_AUTHORIZE_RPS`      | Rate limit (requests/sec) for `/oauth2/authorize`                                           | `5`                             |
+| `AS_RATE_LIMIT_AUTHORIZE_BURST`    | Burst limit for `/oauth2/authorize`                                                         | `10`                            |
+| `AS_RATE_LIMIT_TOKEN_RPS`          | Rate limit (requests/sec) for `/oauth2/token`                                               | `10`                            |
+| `AS_RATE_LIMIT_TOKEN_BURST`        | Burst limit for `/oauth2/token`                                                             | `20`                            |
+| `AS_RATE_LIMIT_INTROSPECT_RPS`     | Rate limit (requests/sec) for `/oauth2/introspect`                                          | `10`                            |
+| `AS_RATE_LIMIT_INTROSPECT_BURST`   | Burst limit for `/oauth2/introspect`                                                        | `20`                            |
+| `AS_RATE_LIMIT_ADMIN_RPS`          | Rate limit (requests/sec) for `/admin/*`                                                    | `5`                             |
+| `AS_RATE_LIMIT_ADMIN_BURST`        | Burst limit for `/admin/*`                                                                  | `10`                            |
 
 All configuration is logged at server startup (secrets are masked in logs).
 

--- a/cmd/as/main.go
+++ b/cmd/as/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -22,6 +24,7 @@ import (
 	internaljwt "go_oauth2_server/internal/jwt"
 	"go_oauth2_server/internal/obo"
 	"go_oauth2_server/internal/random"
+	"go_oauth2_server/internal/ratelimit"
 	"go_oauth2_server/internal/store"
 	memstore "go_oauth2_server/internal/store/mem"
 	sqlstore "go_oauth2_server/internal/store/sqlite"
@@ -50,9 +53,12 @@ func main() {
 		}
 	}
 
-	signer, err := internaljwt.NewSigner(cfg.Issuer, cfg.Audience, cfg.SigningKeyPEM, cfg.SigningKeyID, cfg.AccessTokenTTL, cfg.RefreshTokenTTL, cfg.OBOTokenTTL)
+	signer, err := buildSigner(cfg)
 	if err != nil {
 		log.Fatalf("init signer: %v", err)
+	}
+	if cfg.SigningKeyDir != "" && cfg.SigningKeyRotationInterval > 0 {
+		startKeyRotation(cfg, signer)
 	}
 	oboService := &obo.Service{Signer: signer, Issuer: cfg.Issuer, Audience: cfg.Audience, OBOTTL: cfg.OBOTokenTTL}
 
@@ -69,16 +75,22 @@ func main() {
 	}
 
 	identityHandler := identity.NewHandler(identityStore, cfg.AdminToken)
+	authorizeLimiter := ratelimit.NewLimiter(float64(cfg.AuthorizeRateLimitRPS), cfg.AuthorizeRateLimitBurst)
+	tokenLimiter := ratelimit.NewLimiter(float64(cfg.TokenRateLimitRPS), cfg.TokenRateLimitBurst)
+	introspectLimiter := ratelimit.NewLimiter(float64(cfg.IntrospectRateLimitRPS), cfg.IntrospectRateLimitBurst)
+	adminLimiter := ratelimit.NewLimiter(float64(cfg.AdminRateLimitRPS), cfg.AdminRateLimitBurst)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", methodHandler(http.MethodGet, func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
 	}))
-	mux.HandleFunc("/.well-known/jwks.json", methodHandler(http.MethodGet, srv.handleJWKS))
-	mux.HandleFunc("/authorize", methodHandler(http.MethodGet, srv.handleAuthorize))
-	mux.HandleFunc("/token", methodHandler(http.MethodPost, srv.handleToken))
-	mux.HandleFunc("/oauth2/authorize", methodHandler(http.MethodGet, srv.handleAuthorize))
-	mux.HandleFunc("/oauth2/token", methodHandler(http.MethodPost, srv.handleToken))
+	mux.Handle("/.well-known/jwks.json", methodHandler(http.MethodGet, srv.handleJWKS))
+	mux.Handle("/authorize", rateLimitMiddleware(authorizeLimiter, methodHandler(http.MethodGet, srv.handleAuthorize)))
+	mux.Handle("/token", rateLimitMiddleware(tokenLimiter, methodHandler(http.MethodPost, srv.handleToken)))
+	mux.Handle("/oauth2/authorize", rateLimitMiddleware(authorizeLimiter, methodHandler(http.MethodGet, srv.handleAuthorize)))
+	mux.Handle("/oauth2/token", rateLimitMiddleware(tokenLimiter, methodHandler(http.MethodPost, srv.handleToken)))
+	mux.Handle("/oauth2/introspect", rateLimitMiddleware(introspectLimiter, methodHandler(http.MethodPost, srv.handleIntrospect)))
+	mux.Handle("/oauth2/revoke", rateLimitMiddleware(tokenLimiter, methodHandler(http.MethodPost, srv.handleRevoke)))
 	mux.HandleFunc("/mint-assertion", methodHandler(http.MethodPost, srv.handleSubjectAssertion))
 	mux.HandleFunc("/subject-assertion", methodHandler(http.MethodPost, srv.handleSubjectAssertion))
 	mux.HandleFunc("/register/human", methodHandler(http.MethodPost, identityHandler.CreateHuman))
@@ -115,10 +127,11 @@ func main() {
 	adminMux := http.NewServeMux()
 	adminMux.HandleFunc("/admin/clients", adminHandler.HandleClients)
 	adminMux.HandleFunc("/admin/clients/", adminHandler.HandleClient)
+	adminHandlerWithLimit := rateLimitMiddleware(adminLimiter, adminMux)
 
 	go func() {
 		log.Printf("Admin API listening on %s", cfg.AdminAddr)
-		if err := http.ListenAndServe(cfg.AdminAddr, loggingMiddleware(adminMux)); err != nil {
+		if err := http.ListenAndServe(cfg.AdminAddr, loggingMiddleware(adminHandlerWithLimit)); err != nil {
 			log.Fatalf("admin listen: %v", err)
 		}
 	}()
@@ -320,15 +333,37 @@ func (s *authorizationServer) handleAuthorize(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	codeChallenge := strings.TrimSpace(q.Get("code_challenge"))
+	codeChallengeMethod := strings.ToUpper(strings.TrimSpace(q.Get("code_challenge_method")))
+	if codeChallenge != "" && codeChallengeMethod == "" {
+		codeChallengeMethod = "PLAIN"
+	}
+	if client.Type == store.ClientTypePublic {
+		if codeChallenge == "" {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_request", "code_challenge required for public clients")
+			return
+		}
+		if codeChallengeMethod != "S256" {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_request", "code_challenge_method must be S256")
+			return
+		}
+	} else if codeChallenge != "" && codeChallengeMethod != "S256" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "code_challenge_method must be S256")
+		return
+	}
+
 	code := random.NewID()
 	state := q.Get("state")
 	s.store.SaveCode(store.AuthorizationCode{
-		Code:        code,
-		ClientID:    clientID,
-		HumanID:     human.ID,
-		RedirectURI: redirectURI,
-		Scope:       scope,
-		ExpiresAt:   time.Now().Add(s.cfg.CodeTTL),
+		Code:                code,
+		ClientID:            clientID,
+		HumanID:             human.ID,
+		RedirectURI:         redirectURI,
+		Scope:               scope,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
+		IssuedAt:            time.Now().UTC(),
+		ExpiresAt:           time.Now().Add(s.cfg.CodeTTL),
 	})
 
 	redirect, err := url.Parse(redirectURI)
@@ -371,6 +406,88 @@ func (s *authorizationServer) handleToken(w http.ResponseWriter, r *http.Request
 	default:
 		writeOAuthError(w, http.StatusBadRequest, "unsupported_grant_type", "grant type not supported")
 	}
+}
+
+func (s *authorizationServer) handleIntrospect(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "unable to parse form")
+		return
+	}
+	client, err := s.authenticateClient(r, "")
+	if err != nil {
+		writeOAuthError(w, http.StatusUnauthorized, "invalid_client", err.Error())
+		return
+	}
+	token := strings.TrimSpace(r.PostFormValue("token"))
+	if token == "" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "token required")
+		return
+	}
+	tokenTypeHint := strings.TrimSpace(r.PostFormValue("token_type_hint"))
+	if tokenTypeHint == "" || tokenTypeHint == "refresh_token" {
+		if rt, ok := s.store.GetRefreshToken(token); ok && rt.ClientID == client.ID {
+			active := time.Now().Before(rt.ExpiresAt) && rt.ConsumedAt.IsZero()
+			writeJSON(w, http.StatusOK, map[string]any{
+				"active":     active,
+				"sub":        rt.HumanID,
+				"client_id":  rt.ClientID,
+				"scope":      rt.Scope,
+				"exp":        rt.ExpiresAt.Unix(),
+				"iat":        rt.IssuedAt.Unix(),
+				"token_type": "refresh_token",
+			})
+			return
+		}
+		if tokenTypeHint == "refresh_token" {
+			writeJSON(w, http.StatusOK, map[string]any{"active": false})
+			return
+		}
+	}
+
+	claims, err := s.verifyAccessToken(token)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"active": false})
+		return
+	}
+	sub, _ := claims["sub"].(string)
+	scope, _ := claims["scope"].(string)
+	clientID, _ := claims["client_id"].(string)
+	exp, _ := claims["exp"]
+	iat, _ := claims["iat"]
+	aud := claims["aud"]
+	iss := claims["iss"]
+	writeJSON(w, http.StatusOK, map[string]any{
+		"active":     true,
+		"sub":        sub,
+		"client_id":  clientID,
+		"scope":      scope,
+		"exp":        exp,
+		"iat":        iat,
+		"aud":        aud,
+		"iss":        iss,
+		"token_type": "access_token",
+	})
+}
+
+func (s *authorizationServer) handleRevoke(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "unable to parse form")
+		return
+	}
+	if _, err := s.authenticateClient(r, ""); err != nil {
+		writeOAuthError(w, http.StatusUnauthorized, "invalid_client", err.Error())
+		return
+	}
+	token := strings.TrimSpace(r.PostFormValue("token"))
+	if token == "" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "token required")
+		return
+	}
+	tokenTypeHint := strings.TrimSpace(r.PostFormValue("token_type_hint"))
+	if tokenTypeHint == "" || tokenTypeHint == "refresh_token" {
+		s.store.RevokeRefreshTokenFamily(token)
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *authorizationServer) handleSubjectAssertion(w http.ResponseWriter, r *http.Request) {
@@ -443,6 +560,20 @@ func (s *authorizationServer) handleAuthorizationCodeGrant(w http.ResponseWriter
 		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "redirect_uri mismatch")
 		return
 	}
+	if record.CodeChallenge != "" {
+		codeVerifier := strings.TrimSpace(r.PostFormValue("code_verifier"))
+		if !validCodeVerifier(codeVerifier) {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "invalid code_verifier")
+			return
+		}
+		if !verifyPKCE(record.CodeChallengeMethod, record.CodeChallenge, codeVerifier) {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "code_verifier mismatch")
+			return
+		}
+	} else if client.Type == store.ClientTypePublic {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "code_verifier required for public clients")
+		return
+	}
 	if !scopeSubsetList(record.Scope, client.Scopes) {
 		writeOAuthError(w, http.StatusBadRequest, "invalid_scope", "requested scope not allowed")
 		return
@@ -467,11 +598,14 @@ func (s *authorizationServer) handleAuthorizationCodeGrant(w http.ResponseWriter
 		return
 	}
 	refresh := random.NewID()
+	familyID := random.NewID()
 	s.store.SaveRefreshToken(store.RefreshToken{
 		Token:     refresh,
 		ClientID:  client.ID,
 		HumanID:   human.ID,
 		Scope:     record.Scope,
+		FamilyID:  familyID,
+		IssuedAt:  time.Now().UTC(),
 		ExpiresAt: time.Now().Add(s.cfg.RefreshTokenTTL),
 	})
 	writeTokenResponse(w, map[string]any{
@@ -494,12 +628,17 @@ func (s *authorizationServer) handleRefreshTokenGrant(w http.ResponseWriter, r *
 		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "unknown refresh token")
 		return
 	}
+	if !rt.ConsumedAt.IsZero() {
+		s.store.RevokeRefreshTokenFamily(token)
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token reuse detected")
+		return
+	}
 	if !scopeSubsetList(rt.Scope, client.Scopes) {
 		writeOAuthError(w, http.StatusBadRequest, "invalid_scope", "requested scope not allowed")
 		return
 	}
 	if time.Now().After(rt.ExpiresAt) {
-		s.store.DeleteRefreshToken(token)
+		s.store.RevokeRefreshTokenFamily(token)
 		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token expired")
 		return
 	}
@@ -517,11 +656,30 @@ func (s *authorizationServer) handleRefreshTokenGrant(w http.ResponseWriter, r *
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}
+	newRefresh := random.NewID()
+	next := store.RefreshToken{
+		Token:     newRefresh,
+		ClientID:  rt.ClientID,
+		HumanID:   rt.HumanID,
+		Scope:     rt.Scope,
+		FamilyID:  rt.FamilyID,
+		IssuedAt:  time.Now().UTC(),
+		ExpiresAt: rt.ExpiresAt,
+	}
+	if _, err := s.store.RotateRefreshToken(token, next); err != nil {
+		if errors.Is(err, store.ErrRefreshTokenConsumed) || errors.Is(err, store.ErrRefreshTokenFamilyReset) {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token reuse detected")
+			return
+		}
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "unknown refresh token")
+		return
+	}
 	writeTokenResponse(w, map[string]any{
-		"access_token": access,
-		"token_type":   "bearer",
-		"expires_in":   expiresIn,
-		"scope":        rt.Scope,
+		"access_token":  access,
+		"token_type":    "bearer",
+		"expires_in":    expiresIn,
+		"refresh_token": newRefresh,
+		"scope":         rt.Scope,
 	})
 }
 
@@ -745,12 +903,72 @@ func writeOAuthError(w http.ResponseWriter, status int, code, description string
 	})
 }
 
+func rateLimitMiddleware(limiter *ratelimit.Limiter, next http.Handler) http.Handler {
+	if limiter == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !limiter.Allow(clientIP(r)) {
+			writeOAuthError(w, http.StatusTooManyRequests, "rate_limited", "too many requests")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func clientIP(r *http.Request) string {
+	if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
+		parts := strings.Split(forwarded, ",")
+		if len(parts) > 0 {
+			return strings.TrimSpace(parts[0])
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}
+
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		next.ServeHTTP(w, r)
 		log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
 	})
+}
+
+func validCodeVerifier(verifier string) bool {
+	if len(verifier) < 43 || len(verifier) > 128 {
+		return false
+	}
+	for _, r := range verifier {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '.' || r == '_' || r == '~' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func verifyPKCE(method, challenge, verifier string) bool {
+	if method != "S256" {
+		return false
+	}
+	digest := sha256.Sum256([]byte(verifier))
+	expected := base64.RawURLEncoding.EncodeToString(digest[:])
+	return subtleConstantTimeCompare(expected, challenge)
+}
+
+func subtleConstantTimeCompare(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var diff byte
+	for i := 0; i < len(a); i++ {
+		diff |= a[i] ^ b[i]
+	}
+	return diff == 0
 }
 
 func methodHandler(method string, fn http.HandlerFunc) http.HandlerFunc {
@@ -797,7 +1015,7 @@ func loadDotEnv() {
 }
 
 func logConfiguration(cfg *config.Config) {
-	log.Printf("config: issuer=%s audience=%s allow_legacy=%t admin_token_set=%t seed=%s client_store=%s clients_db=%s admin_addr=%s code_ttl=%s access_ttl=%s refresh_ttl=%s obo_ttl=%s", cfg.Issuer, cfg.Audience, cfg.AllowLegacy, cfg.AdminToken != "", cfg.SeedIdentitiesPath, cfg.ClientStoreDriver, cfg.ClientDBPath, cfg.AdminAddr, cfg.CodeTTL, cfg.AccessTokenTTL, cfg.RefreshTokenTTL, cfg.OBOTokenTTL)
+	log.Printf("config: issuer=%s audience=%s allow_legacy=%t admin_token_set=%t seed=%s client_store=%s clients_db=%s admin_addr=%s code_ttl=%s access_ttl=%s refresh_ttl=%s obo_ttl=%s signing_key_dir=%s key_rotation_interval=%s authorize_rl=%d/%d token_rl=%d/%d introspect_rl=%d/%d admin_rl=%d/%d", cfg.Issuer, cfg.Audience, cfg.AllowLegacy, cfg.AdminToken != "", cfg.SeedIdentitiesPath, cfg.ClientStoreDriver, cfg.ClientDBPath, cfg.AdminAddr, cfg.CodeTTL, cfg.AccessTokenTTL, cfg.RefreshTokenTTL, cfg.OBOTokenTTL, cfg.SigningKeyDir, cfg.SigningKeyRotationInterval, cfg.AuthorizeRateLimitRPS, cfg.AuthorizeRateLimitBurst, cfg.TokenRateLimitRPS, cfg.TokenRateLimitBurst, cfg.IntrospectRateLimitRPS, cfg.IntrospectRateLimitBurst, cfg.AdminRateLimitRPS, cfg.AdminRateLimitBurst)
 }
 
 func buildClientStore(cfg *config.Config) (store.ClientStore, error) {
@@ -905,6 +1123,55 @@ func scopeSubset(requested string, subjectScope any) bool {
 		}
 	}
 	return true
+}
+
+func (s *authorizationServer) verifyAccessToken(token string) (internaljwt.MapClaims, error) {
+	claims, err := s.signer.Verify(token, s.cfg.Audience)
+	if err == nil {
+		return claims, nil
+	}
+	if s.cfg.Issuer != "" && s.cfg.Issuer != s.cfg.Audience {
+		return s.signer.Verify(token, s.cfg.Issuer)
+	}
+	return nil, err
+}
+
+func buildSigner(cfg *config.Config) (*internaljwt.Signer, error) {
+	var (
+		keySet *internaljwt.KeySet
+		err    error
+	)
+	if cfg.SigningKeyDir != "" {
+		keySet, err = internaljwt.LoadKeySetFromDir(cfg.SigningKeyDir, cfg.SigningKeyID)
+	} else {
+		keySet, err = internaljwt.LoadKeySetFromPEM(cfg.SigningKeyPEM, cfg.SigningKeyID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return internaljwt.NewSignerWithKeySet(cfg.Issuer, cfg.Audience, keySet, cfg.AccessTokenTTL, cfg.RefreshTokenTTL, cfg.OBOTokenTTL)
+}
+
+func startKeyRotation(cfg *config.Config, signer *internaljwt.Signer) {
+	interval := cfg.SigningKeyRotationInterval
+	if interval <= 0 || cfg.SigningKeyDir == "" {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	go func() {
+		for range ticker.C {
+			keySet, err := internaljwt.LoadKeySetFromDir(cfg.SigningKeyDir, cfg.SigningKeyID)
+			if err != nil {
+				log.Printf("key rotation reload failed: %v", err)
+				continue
+			}
+			if err := signer.UpdateKeys(keySet); err != nil {
+				log.Printf("key rotation update failed: %v", err)
+				continue
+			}
+			log.Printf("key rotation: reloaded %d keys (active kid=%s)", len(keySet.PrivateKeys), keySet.ActiveKeyID)
+		}
+	}()
 }
 
 func seedIdentities(ctx context.Context, store identity.Store, path string) error {

--- a/cmd/as/main_test.go
+++ b/cmd/as/main_test.go
@@ -22,6 +22,7 @@ import (
 	"go_oauth2_server/internal/identity"
 	internaljwt "go_oauth2_server/internal/jwt"
 	"go_oauth2_server/internal/obo"
+	"go_oauth2_server/internal/ratelimit"
 	"go_oauth2_server/internal/store"
 	memstore "go_oauth2_server/internal/store/mem"
 )
@@ -127,6 +128,347 @@ func TestAuthorizationCodeFlowWithRegisteredHuman(t *testing.T) {
 	}
 	if claims["email"] != human.Email {
 		t.Fatalf("expected email claim")
+	}
+}
+
+func TestPublicClientRequiresPKCE(t *testing.T) {
+	ctx := context.Background()
+	idStore := memstore.New()
+	human, err := idStore.CreateHuman(ctx, identity.Human{Email: "pkce@example.com", Name: "PKCE User"})
+	if err != nil {
+		t.Fatalf("create human: %v", err)
+	}
+
+	srv, server := newTestServer(t, idStore)
+	defer server.Close()
+
+	_, err = srv.clients.CreateClient(ctx, store.Client{
+		ID:           "public-client",
+		Type:         store.ClientTypePublic,
+		RedirectURIs: []string{"http://localhost/callback"},
+		GrantTypes:   []string{store.GrantAuthorizationCode},
+		Scopes:       []string{"openid"},
+	})
+	if err != nil {
+		t.Fatalf("seed public client: %v", err)
+	}
+
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
+	authURL := fmt.Sprintf("%s/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s", server.URL, url.QueryEscape("public-client"), url.QueryEscape("http://localhost/callback"), url.QueryEscape(human.ID))
+	resp, err := client.Get(authURL)
+	if err != nil {
+		t.Fatalf("authorize request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 without PKCE, got %d", resp.StatusCode)
+	}
+
+	codeVerifier := "pkce-code-verifier-1234567890abcdef1234567890abcdef1234567"
+	challenge := pkceChallenge(codeVerifier)
+	authURL = fmt.Sprintf("%s/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s&code_challenge=%s&code_challenge_method=plain", server.URL, url.QueryEscape("public-client"), url.QueryEscape("http://localhost/callback"), url.QueryEscape(human.ID), url.QueryEscape(challenge))
+	resp, err = client.Get(authURL)
+	if err != nil {
+		t.Fatalf("authorize request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for plain PKCE, got %d", resp.StatusCode)
+	}
+
+	authURL = fmt.Sprintf("%s/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s&code_challenge=%s&code_challenge_method=S256", server.URL, url.QueryEscape("public-client"), url.QueryEscape("http://localhost/callback"), url.QueryEscape(human.ID), url.QueryEscape(challenge))
+	resp, err = client.Get(authURL)
+	if err != nil {
+		t.Fatalf("authorize request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	location := resp.Header.Get("Location")
+	locURL, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	code := locURL.Query().Get("code")
+	if code == "" {
+		t.Fatal("expected authorization code")
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("client_id", "public-client")
+	form.Set("code_verifier", codeVerifier)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/oauth2/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("create token request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("token request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func TestRefreshTokenRotationAndReuseDetection(t *testing.T) {
+	ctx := context.Background()
+	idStore := memstore.New()
+	human, err := idStore.CreateHuman(ctx, identity.Human{Email: "refresh@example.com", Name: "Refresh User"})
+	if err != nil {
+		t.Fatalf("create human: %v", err)
+	}
+
+	_, server := newTestServer(t, idStore)
+	defer server.Close()
+
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
+	authURL := fmt.Sprintf("%s/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s", server.URL, url.QueryEscape(testClientID), url.QueryEscape("http://localhost/callback"), url.QueryEscape(human.ID))
+	resp, err := client.Get(authURL)
+	if err != nil {
+		t.Fatalf("authorize request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	locURL, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	code := locURL.Query().Get("code")
+	if code == "" {
+		t.Fatal("expected authorization code")
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("client_id", testClientID)
+	form.Set("client_secret", testClientSecret)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/oauth2/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("create token request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("token request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+	var tokenResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	refresh, _ := tokenResp["refresh_token"].(string)
+	if refresh == "" {
+		t.Fatal("missing refresh token")
+	}
+
+	refreshForm := url.Values{}
+	refreshForm.Set("grant_type", "refresh_token")
+	refreshForm.Set("refresh_token", refresh)
+	refreshForm.Set("client_id", testClientID)
+	refreshForm.Set("client_secret", testClientSecret)
+	resp, err = http.PostForm(server.URL+"/oauth2/token", refreshForm)
+	if err != nil {
+		t.Fatalf("refresh request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+	var refreshResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&refreshResp); err != nil {
+		t.Fatalf("decode refresh response: %v", err)
+	}
+	newRefresh, _ := refreshResp["refresh_token"].(string)
+	if newRefresh == "" {
+		t.Fatal("missing rotated refresh token")
+	}
+	if newRefresh == refresh {
+		t.Fatal("refresh token did not rotate")
+	}
+
+	resp, err = http.PostForm(server.URL+"/oauth2/token", refreshForm)
+	if err != nil {
+		t.Fatalf("refresh request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 on reuse, got %d", resp.StatusCode)
+	}
+
+	refreshForm.Set("refresh_token", newRefresh)
+	resp, err = http.PostForm(server.URL+"/oauth2/token", refreshForm)
+	if err != nil {
+		t.Fatalf("refresh request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 after family revoke, got %d", resp.StatusCode)
+	}
+}
+
+func TestIntrospectAndRevoke(t *testing.T) {
+	ctx := context.Background()
+	idStore := memstore.New()
+	human, err := idStore.CreateHuman(ctx, identity.Human{Email: "introspect@example.com", Name: "Introspect User"})
+	if err != nil {
+		t.Fatalf("create human: %v", err)
+	}
+
+	_, server := newTestServer(t, idStore)
+	defer server.Close()
+
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
+	authURL := fmt.Sprintf("%s/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&scope=openid&human_id=%s", server.URL, url.QueryEscape(testClientID), url.QueryEscape("http://localhost/callback"), url.QueryEscape(human.ID))
+	resp, err := client.Get(authURL)
+	if err != nil {
+		t.Fatalf("authorize request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	locURL, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	code := locURL.Query().Get("code")
+	if code == "" {
+		t.Fatal("expected authorization code")
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("client_id", testClientID)
+	form.Set("client_secret", testClientSecret)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/oauth2/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("create token request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("token request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+	var tokenResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	refresh, _ := tokenResp["refresh_token"].(string)
+	if refresh == "" {
+		t.Fatal("missing refresh token")
+	}
+
+	introspectForm := url.Values{}
+	introspectForm.Set("token", refresh)
+	introspectForm.Set("token_type_hint", "refresh_token")
+	introspectForm.Set("client_id", testClientID)
+	introspectForm.Set("client_secret", testClientSecret)
+	resp, err = http.PostForm(server.URL+"/oauth2/introspect", introspectForm)
+	if err != nil {
+		t.Fatalf("introspect request: %v", err)
+	}
+	defer resp.Body.Close()
+	var introspectResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&introspectResp); err != nil {
+		t.Fatalf("decode introspect response: %v", err)
+	}
+	if active, _ := introspectResp["active"].(bool); !active {
+		t.Fatal("expected refresh token active")
+	}
+
+	revokeForm := url.Values{}
+	revokeForm.Set("token", refresh)
+	revokeForm.Set("token_type_hint", "refresh_token")
+	revokeForm.Set("client_id", testClientID)
+	revokeForm.Set("client_secret", testClientSecret)
+	resp, err = http.PostForm(server.URL+"/oauth2/revoke", revokeForm)
+	if err != nil {
+		t.Fatalf("revoke request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	resp, err = http.PostForm(server.URL+"/oauth2/introspect", introspectForm)
+	if err != nil {
+		t.Fatalf("introspect request: %v", err)
+	}
+	defer resp.Body.Close()
+	introspectResp = map[string]any{}
+	if err := json.NewDecoder(resp.Body).Decode(&introspectResp); err != nil {
+		t.Fatalf("decode introspect response: %v", err)
+	}
+	if active, _ := introspectResp["active"].(bool); active {
+		t.Fatal("expected refresh token inactive after revoke")
+	}
+}
+
+func TestTokenRateLimit(t *testing.T) {
+	idStore := memstore.New()
+
+	cfg := &config.Config{
+		Issuer:          "http://test-as",
+		Audience:        "http://test-rs",
+		SigningKeyPEM:   []byte(testSigningKeyPEM),
+		SigningKeyID:    "test-key",
+		CodeTTL:         time.Minute,
+		AccessTokenTTL:  time.Hour,
+		RefreshTokenTTL: time.Hour,
+		OBOTokenTTL:     time.Minute,
+	}
+	srv, warmServer := newTestServerWithConfig(t, idStore, cfg)
+	warmServer.Close()
+
+	limiter := ratelimit.NewLimiter(1, 1)
+	mux := http.NewServeMux()
+	mux.Handle("/oauth2/token", rateLimitMiddleware(limiter, methodHandler(http.MethodPost, srv.handleToken)))
+	rateServer := httptest.NewServer(loggingMiddleware(mux))
+	defer rateServer.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", testClientID)
+	form.Set("client_secret", testClientSecret)
+	resp, err := http.PostForm(rateServer.URL+"/oauth2/token", form)
+	if err != nil {
+		t.Fatalf("token request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	resp, err = http.PostForm(rateServer.URL+"/oauth2/token", form)
+	if err != nil {
+		t.Fatalf("token request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", resp.StatusCode)
 	}
 }
 
@@ -587,7 +929,11 @@ func newTestServerWithConfig(t *testing.T, identityStore identity.Store, cfg *co
 	if err != nil {
 		t.Fatalf("seed client: %v", err)
 	}
-	signer, err := internaljwt.NewSigner(cfg.Issuer, cfg.Audience, cfg.SigningKeyPEM, cfg.SigningKeyID, cfg.AccessTokenTTL, cfg.RefreshTokenTTL, cfg.OBOTokenTTL)
+	keySet, err := internaljwt.LoadKeySetFromPEM(cfg.SigningKeyPEM, cfg.SigningKeyID)
+	if err != nil {
+		t.Fatalf("init signer: %v", err)
+	}
+	signer, err := internaljwt.NewSignerWithKeySet(cfg.Issuer, cfg.Audience, keySet, cfg.AccessTokenTTL, cfg.RefreshTokenTTL, cfg.OBOTokenTTL)
 	if err != nil {
 		t.Fatalf("init signer: %v", err)
 	}
@@ -612,6 +958,8 @@ func newTestServerWithConfig(t *testing.T, identityStore identity.Store, cfg *co
 	mux.HandleFunc("/token", methodHandler(http.MethodPost, srv.handleToken))
 	mux.HandleFunc("/oauth2/authorize", methodHandler(http.MethodGet, srv.handleAuthorize))
 	mux.HandleFunc("/oauth2/token", methodHandler(http.MethodPost, srv.handleToken))
+	mux.HandleFunc("/oauth2/introspect", methodHandler(http.MethodPost, srv.handleIntrospect))
+	mux.HandleFunc("/oauth2/revoke", methodHandler(http.MethodPost, srv.handleRevoke))
 	mux.HandleFunc("/subject-assertion", methodHandler(http.MethodPost, srv.handleSubjectAssertion))
 	mux.HandleFunc("/register/human", methodHandler(http.MethodPost, identityHandler.CreateHuman))
 	mux.HandleFunc("/register/agent", methodHandler(http.MethodPost, identityHandler.CreateAgent))
@@ -674,4 +1022,9 @@ func verifyWithJWKS(token string, jwk map[string]any) (map[string]any, error) {
 		return nil, fmt.Errorf("unmarshal claims: %w", err)
 	}
 	return claims, nil
+}
+
+func pkceChallenge(verifier string) string {
+	digest := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(digest[:])
 }

--- a/cmd/rs/main.go
+++ b/cmd/rs/main.go
@@ -20,7 +20,16 @@ func main() {
 		log.Fatalf("load config: %v", err)
 	}
 
-	signer, err := internaljwt.NewSigner(cfg.Issuer, cfg.Audience, cfg.SigningKeyPEM, cfg.KeyID, cfg.AccessTTL, cfg.RefreshTTL, cfg.AccessTTL)
+	var keySet *internaljwt.KeySet
+	if cfg.SigningKeyDir != "" {
+		keySet, err = internaljwt.LoadKeySetFromDir(cfg.SigningKeyDir, cfg.KeyID)
+	} else {
+		keySet, err = internaljwt.LoadKeySetFromPEM(cfg.SigningKeyPEM, cfg.KeyID)
+	}
+	if err != nil {
+		log.Fatalf("init signer: %v", err)
+	}
+	signer, err := internaljwt.NewSignerWithKeySet(cfg.Issuer, cfg.Audience, keySet, cfg.AccessTTL, cfg.RefreshTTL, cfg.AccessTTL)
 	if err != nil {
 		log.Fatalf("init signer: %v", err)
 	}
@@ -75,6 +84,7 @@ type resourceConfig struct {
 	Issuer        string
 	Audience      string
 	SigningKeyPEM []byte
+	SigningKeyDir string
 	KeyID         string
 	AccessTTL     time.Duration
 	RefreshTTL    time.Duration
@@ -94,6 +104,7 @@ func loadConfig() (*resourceConfig, error) {
 		Issuer:        issuer,
 		Audience:      audience,
 		SigningKeyPEM: key.SigningKeyPEM,
+		SigningKeyDir: key.SigningKeyDir,
 		KeyID:         getEnv("AS_SIGNING_KEY_ID", "dev-rs256"),
 		AccessTTL:     15 * time.Minute,
 		RefreshTTL:    24 * time.Hour,

--- a/docs/PROD_READINESS_AUDIT.md
+++ b/docs/PROD_READINESS_AUDIT.md
@@ -1,0 +1,81 @@
+# Production Readiness Audit Report
+
+## Current State Summary
+
+### Entry points
+- **Authorization Server (AS):** `cmd/as/main.go` starts the AS, registers HTTP routes for OAuth, identity registration, and JWKS, and starts the admin API listener on a separate address.【F:cmd/as/main.go†L26-L121】
+- **Resource Server (RS):** `cmd/rs/main.go` starts the RS and exposes a single protected resource endpoint, plus `/healthz`.【F:cmd/rs/main.go†L17-L86】
+- **CLI tooling:** `cmd/seed-clients/main.go` seeds OAuth clients into the configured client store.【F:cmd/seed-clients/main.go†L1-L162】
+
+### Endpoints implemented
+**Authorization Server (port 8080 by default)**
+- `/.well-known/jwks.json` (JWKS)【F:cmd/as/main.go†L77-L264】
+- `/authorize` and `/oauth2/authorize` (authorization code)【F:cmd/as/main.go†L78-L83】【F:cmd/as/main.go†L266-L347】
+- `/token` and `/oauth2/token` (token endpoint supporting multiple grants)【F:cmd/as/main.go†L79-L84】【F:cmd/as/main.go†L350-L392】
+- `/subject-assertion` and `/mint-assertion` (subject assertion JWTs)【F:cmd/as/main.go†L82-L83】【F:cmd/as/main.go†L394-L449】
+- Identity registration APIs:
+  - `/register/human`, `/register/agent` (create)【F:cmd/as/main.go†L84-L85】
+  - `/humans`, `/agents` (list)【F:cmd/as/main.go†L86-L87】
+  - `/humans/{id}`, `/agents/{id}` (get/delete)【F:cmd/as/main.go†L88-L109】
+- `/healthz` (health check)【F:cmd/as/main.go†L73-L76】
+- `/oauth2/introspect` (token introspection)【F:cmd/as/main.go†L86-L90】【F:cmd/as/main.go†L396-L469】
+- `/oauth2/revoke` (token revocation)【F:cmd/as/main.go†L87-L90】【F:cmd/as/main.go†L471-L499】
+
+**Admin API (bound to `AS_ADMIN_ADDR`, default `127.0.0.1:8082`)**
+- `GET/POST /admin/clients` (list/create)【F:cmd/as/main.go†L116-L120】【F:internal/admin/clients.go†L19-L68】
+- `GET/PUT/DELETE /admin/clients/{client_id}` (get/update/delete)【F:cmd/as/main.go†L116-L120】【F:internal/admin/clients.go†L70-L158】
+
+**Resource Server (port 9090 by default)**
+- `GET /accounts/{id}/orders/export` (protected OBO resource)【F:cmd/rs/main.go†L29-L72】
+- `/healthz` (health check)【F:cmd/rs/main.go†L28-L33】
+
+**Not implemented**
+- `/.well-known/openid-configuration` (OIDC discovery) is not present in the codebase (only JWKS is served).【F:cmd/as/main.go†L73-L83】
+
+### Supported grants
+- `authorization_code`【F:cmd/as/main.go†L360-L382】
+- `refresh_token`【F:cmd/as/main.go†L360-L382】
+- `client_credentials`【F:cmd/as/main.go†L360-L382】
+- `urn:ietf:params:oauth:grant-type:token-exchange` (RFC 8693 shaped)【F:cmd/as/main.go†L360-L383】【F:cmd/as/main.go†L551-L676】
+
+### Storage model
+- **Authorization codes:** in-memory map in `internal/store.Store` (not persisted).【F:internal/store/store.go†L18-L65】
+- **Refresh tokens:** in-memory map in `internal/store.Store` (not persisted).【F:internal/store/store.go†L18-L86】
+- **Clients:** in-memory or sqlite-backed client store (`AS_CLIENT_STORE` / `AS_CLIENTS_DB`).【F:cmd/as/main.go†L25-L47】【F:cmd/as/main.go†L662-L688】【F:internal/store/mem/client_store.go†L11-L73】【F:internal/store/sqlite/client_store.go†L16-L113】
+- **Identities (humans/agents):** in-memory identity store (`internal/store/mem` for identity storage), optionally seeded from JSON at startup (`SEED_IDENTITIES_JSON`).【F:cmd/as/main.go†L33-L58】【F:cmd/as/main.go†L730-L842】
+
+### Key management
+- **Key source:** RSA private key loaded from `AS_SIGNING_KEY_PEM`/`AS_SIGNING_KEY_PATH` (single key) or from `AS_SIGNING_KEYS_DIR` (multi-key) with `AS_SIGNING_KEY_ID` selecting the active `kid`.【F:internal/config/config.go†L79-L205】【F:internal/jwt/keyset.go†L20-L101】
+- **JWKS:** publishes all loaded RSA public keys with `kid`, `alg=RS256`, `use=sig` for overlap during rotation.【F:internal/jwt/issuer.go†L205-L253】
+- **Rotation:** optional key reload via `AS_SIGNING_KEY_ROTATION_SECONDS` (disabled by default), enabling key overlap without downtime.【F:internal/config/config.go†L109-L139】【F:cmd/as/main.go†L1150-L1178】
+
+### Security controls (current)
+- **Redirect URI validation:** exact string match against client-registered redirect URIs; required when multiple URIs exist.【F:cmd/as/main.go†L284-L315】【F:cmd/as/main.go†L690-L699】
+- **Authorization code TTL and one-time use:** codes are stored with an expiry and consumed on use, with PKCE binding for public clients.【F:cmd/as/main.go†L323-L341】【F:cmd/as/main.go†L451-L510】【F:internal/store/store.go†L18-L67】
+- **PKCE enforcement:** S256 PKCE is required for public clients; `code_verifier` is validated on token exchange.【F:cmd/as/main.go†L323-L341】【F:cmd/as/main.go†L461-L510】
+- **Client authentication:** confidential clients require a matching secret; public clients can use client_id only.【F:cmd/as/main.go†L606-L655】
+- **Refresh token rotation:** refresh tokens rotate on use and reuse revokes the token family.【F:cmd/as/main.go†L506-L577】【F:internal/store/store.go†L67-L150】
+- **Access token claims:** issuer/audience/exp/iat/nbf/jti are set; tokens are RS256-signed with `kid`.【F:internal/jwt/issuer.go†L96-L177】
+- **Token verification (RS):** verifies signature, issuer, audience, expiry/nbf, and rejects non-RS256 headers or unknown `kid` values.【F:internal/jwt/issuer.go†L181-L254】【F:cmd/rs/main.go†L105-L151】
+- **Rate limiting:** token bucket limits for authorize/token/introspect/admin endpoints (configurable).【F:cmd/as/main.go†L70-L121】【F:cmd/as/main.go†L642-L662】
+- **State/CSRF:** `state` is passed through but not validated or required (still a gap for browser flows).【F:cmd/as/main.go†L266-L356】
+- **Logging:** basic request timing logs in AS; admin changes logged as JSON; no request ID or structured logging across the board.【F:cmd/as/main.go†L628-L640】【F:internal/admin/clients.go†L177-L205】
+
+## Gaps & Risks (Prioritized)
+
+### P0 — Must-fix before production
+1. **State/CSRF protection gaps**: `state` is not required or validated, which is risky for browser-based authorization flows.【F:cmd/as/main.go†L266-L356】
+2. **Access token revocation is not enforced**: JWT access tokens remain valid until expiry (no blacklist), so revocation only applies to refresh tokens.【F:cmd/as/main.go†L471-L499】【F:cmd/as/main.go†L506-L577】
+
+### P1 — Should-fix next
+1. **Structured request/audit logging with request_id** is missing; current logs are not structured and lack correlation identifiers.【F:cmd/as/main.go†L628-L640】
+2. **Metrics/health telemetry** not provided beyond `/healthz`; no metrics endpoint or integration docs.
+3. **Admin endpoint hardening**: admin API relies solely on bearer token, bound to localhost but no mTLS or explicit allowlist; needs rate limiting and more rigorous auth hardening.【F:cmd/as/main.go†L110-L121】【F:internal/admin/clients.go†L19-L126】
+4. **Configuration validation** is limited (no warnings on dev key usage or insecure defaults); prod safe defaults are not enforced.【F:internal/config/config.go†L79-L205】
+5. **HA/storage concerns**: codes and refresh tokens remain in memory, limiting HA and crash recovery scenarios.【F:internal/store/store.go†L18-L150】
+
+### P2 — Later / out-of-scope for this pass
+1. **High availability and statelessness**: codes/refresh tokens stored in memory; no HA replication strategy. Needs shared storage (DB/redis) or stateless approach.
+2. **OIDC conformance**: no discovery document, ID token support, or OIDC claims strategy.
+3. **Sender-constrained tokens (DPoP/mTLS)** are not implemented; only bearer tokens are used.
+4. **Database migration tooling** for sqlite client store is not present; schema changes require manual intervention.【F:internal/store/sqlite/client_store.go†L25-L60】

--- a/docs/PROD_READINESS_PLAN.md
+++ b/docs/PROD_READINESS_PLAN.md
@@ -1,0 +1,59 @@
+# Production Readiness Change Plan
+
+## P0 (must implement now)
+**What**
+- Harden authorization code flow: enforce PKCE S256, bind codes to client_id/redirect_uri/code_challenge/scopes, and enforce one-time use + TTL.
+- Implement refresh token rotation with reuse detection and family revocation; if not feasible, disable refresh tokens and document.
+- Enforce strict client authentication on `/oauth2/token` for confidential clients.
+- Implement `/oauth2/revoke` and `/oauth2/introspect` (or clearly document limitations if minimal semantics).
+- Add rate limiting for `/oauth2/authorize`, `/oauth2/token`, `/oauth2/introspect`, and `/admin/*`.
+- Key management improvements: configurable key loading, JWKS with `kid`, and rotation scaffolding with overlap support; restrict algorithms to RS256 only.
+
+**Why**
+- These are critical protocol correctness and security hardening items required for production OAuth deployments.
+
+**Risk**
+- Medium: changes affect token issuance and may break existing dev integrations; must add tests and document configuration changes.
+
+**Tests**
+- `go test ./...`
+- New unit tests covering PKCE validation, code binding, refresh rotation/reuse detection, revocation/introspection, and rate limiting.
+
+## P1 (next)
+**What**
+- Add structured JSON logging with request_id propagation.
+- Add an audit log stream for security events (token issuance, refresh reuse, revocation, admin changes).
+- Add `/metrics` endpoint (Prometheus) or document integration hooks if not feasible in this pass.
+- Harden admin API authentication (stronger auth, stricter validation, rate limiting, and/or localhost binding checks).
+
+**Why**
+- Improves observability, auditability, and operational readiness.
+
+**Risk**
+- Low to medium: mostly additive but may require new config.
+
+**Tests**
+- Unit tests validating request_id presence and audit logging behavior (if structured logging is added).
+
+## P2 (later)
+**What**
+- HA guidance and statelessness notes (shared DB/redis for codes/refresh tokens).
+- Sender-constrained tokens (DPoP/mTLS) if required.
+- Deeper OIDC conformance (discovery, ID tokens, claims).
+- Formal migration strategy for client/identity storage.
+
+**Why**
+- These are larger features and operational concerns that require a broader design effort.
+
+**Risk**
+- Medium to high depending on implementation depth.
+
+**Tests**
+- Integration tests in a staged environment with multi-node setups.
+
+## Out of scope for this pass
+- Full HA architecture design and implementation.
+- Full OIDC certification and conformance suite.
+- DPoP or mTLS sender-constrained token support.
+- Multi-tenant policy engine / complex consent flows.
+

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,34 @@
+# Tokenator Runbook
+
+## Key rotation
+
+### Recommended setup
+1. Store RSA private keys on disk and load them via `AS_SIGNING_KEYS_DIR`.
+2. Name each key file as `<kid>.pem` (for example `2025-01.pem`).
+3. Set `AS_SIGNING_KEY_ID` to the active `kid`.
+4. Optionally set `AS_SIGNING_KEY_ROTATION_SECONDS` to periodically reload keys from disk.
+
+### Rotation procedure
+1. Generate a new RSA key pair and write the private key to `AS_SIGNING_KEYS_DIR` (e.g., `2025-02.pem`).
+2. Update `AS_SIGNING_KEY_ID` to the new `kid` and restart the AS (or wait for the reload interval).
+3. Keep the previous key files in the directory for an overlap window so existing tokens continue to validate.
+4. After the overlap window expires (e.g., > max access token TTL), remove the old key files.
+
+## Incident response
+
+### Revoke a client
+1. Disable or delete the client via the admin API (`DELETE /admin/clients/{client_id}`).
+2. Rotate signing keys if you suspect token leakage or signing key compromise.
+3. Invalidate refresh tokens by revoking the refresh family (`POST /oauth2/revoke` with `token_type_hint=refresh_token`).
+
+### Suspected refresh token theft
+1. Revoke the affected refresh token family using `/oauth2/revoke`.
+2. Require the user/client to re-authenticate and re-consent.
+3. Review logs for repeated reuse errors.
+
+## Backup and restore
+
+- **SQLite client registry** (`AS_CLIENTS_DB`): back up the SQLite database file regularly.
+- **In-memory codes/refresh tokens**: ephemeral; persisting them requires external storage (not yet implemented).
+- **Signing keys**: back up `AS_SIGNING_KEYS_DIR` and store keys in a secret manager or HSM for production.
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,32 +13,50 @@ import (
 
 // Config represents runtime configuration for the authorization server.
 type Config struct {
-	Issuer             string
-	Audience           string
-	SigningKeyPEM      []byte
-	SigningKeyID       string
-	CodeTTL            time.Duration
-	AccessTokenTTL     time.Duration
-	RefreshTokenTTL    time.Duration
-	OBOTokenTTL        time.Duration
-	AdminToken         string
-	AllowLegacy        bool
-	SeedIdentitiesPath string
-	ClientDBPath       string
-	ClientStoreDriver  string
-	AdminAddr          string
+	Issuer                     string
+	Audience                   string
+	SigningKeyPEM              []byte
+	SigningKeyID               string
+	SigningKeyDir              string
+	SigningKeyRotationInterval time.Duration
+	CodeTTL                    time.Duration
+	AccessTokenTTL             time.Duration
+	RefreshTokenTTL            time.Duration
+	OBOTokenTTL                time.Duration
+	AdminToken                 string
+	AllowLegacy                bool
+	SeedIdentitiesPath         string
+	ClientDBPath               string
+	ClientStoreDriver          string
+	AdminAddr                  string
+	AuthorizeRateLimitRPS      int
+	AuthorizeRateLimitBurst    int
+	TokenRateLimitRPS          int
+	TokenRateLimitBurst        int
+	IntrospectRateLimitRPS     int
+	IntrospectRateLimitBurst   int
+	AdminRateLimitRPS          int
+	AdminRateLimitBurst        int
 }
 
 const (
-	defaultIssuer         = "http://localhost:8080"
-	defaultAudience       = "http://localhost:9090"
-	defaultSigningKeyID   = "dev-rs256"
-	defaultCodeTTLSeconds = 120
-	defaultAccessTTL      = 3600
-	defaultRefreshTTL     = 86400
-	defaultOBOTTL         = 900
-	defaultClientDBPath   = "data/clients.db"
-	defaultAdminAddr      = "127.0.0.1:8082"
+	defaultIssuer          = "http://localhost:8080"
+	defaultAudience        = "http://localhost:9090"
+	defaultSigningKeyID    = "dev-rs256"
+	defaultCodeTTLSeconds  = 120
+	defaultAccessTTL       = 3600
+	defaultRefreshTTL      = 86400
+	defaultOBOTTL          = 900
+	defaultClientDBPath    = "data/clients.db"
+	defaultAdminAddr       = "127.0.0.1:8082"
+	defaultAuthorizeRPS    = 5
+	defaultAuthorizeBurst  = 10
+	defaultTokenRPS        = 10
+	defaultTokenBurst      = 20
+	defaultIntrospectRPS   = 10
+	defaultIntrospectBurst = 20
+	defaultAdminRPS        = 5
+	defaultAdminBurst      = 10
 )
 
 const defaultSigningKeyPEM = `-----BEGIN PRIVATE KEY-----
@@ -76,6 +94,7 @@ func Load() (*Config, error) {
 		Issuer:             firstNonEmpty(getEnv("ISSUER", ""), getEnv("AS_ISSUER", defaultIssuer)),
 		Audience:           firstNonEmpty(getEnv("RS_AUDIENCE", ""), getEnv("AS_AUDIENCE", defaultAudience)),
 		SigningKeyID:       getEnv("AS_SIGNING_KEY_ID", defaultSigningKeyID),
+		SigningKeyDir:      getEnv("AS_SIGNING_KEYS_DIR", ""),
 		AdminToken:         firstNonEmpty(getEnv("AS_ADMIN_TOKEN", ""), getEnv("ADMIN_TOKEN", "")),
 		SeedIdentitiesPath: getEnv("SEED_IDENTITIES_JSON", ""),
 		ClientDBPath:       getEnv("AS_CLIENTS_DB", defaultClientDBPath),
@@ -83,11 +102,19 @@ func Load() (*Config, error) {
 		AdminAddr:          getEnv("AS_ADMIN_ADDR", defaultAdminAddr),
 	}
 
-	signingKey, err := loadSigningKeyPEM()
+	if cfg.SigningKeyDir == "" {
+		signingKey, err := loadSigningKeyPEM()
+		if err != nil {
+			return nil, err
+		}
+		cfg.SigningKeyPEM = signingKey
+	}
+
+	rotationSeconds, err := parseDurationSecondsAllowZero("AS_SIGNING_KEY_ROTATION_SECONDS", 0)
 	if err != nil {
 		return nil, err
 	}
-	cfg.SigningKeyPEM = signingKey
+	cfg.SigningKeyRotationInterval = rotationSeconds
 
 	codeTTL, err := parseDurationSeconds("AS_CODE_TTL_SECONDS", defaultCodeTTLSeconds)
 	if err != nil {
@@ -118,6 +145,47 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 	cfg.AllowLegacy = allowLegacy
+
+	authorizeRPS, err := parseIntAllowZero("AS_RATE_LIMIT_AUTHORIZE_RPS", defaultAuthorizeRPS)
+	if err != nil {
+		return nil, err
+	}
+	authorizeBurst, err := parseIntAllowZero("AS_RATE_LIMIT_AUTHORIZE_BURST", defaultAuthorizeBurst)
+	if err != nil {
+		return nil, err
+	}
+	tokenRPS, err := parseIntAllowZero("AS_RATE_LIMIT_TOKEN_RPS", defaultTokenRPS)
+	if err != nil {
+		return nil, err
+	}
+	tokenBurst, err := parseIntAllowZero("AS_RATE_LIMIT_TOKEN_BURST", defaultTokenBurst)
+	if err != nil {
+		return nil, err
+	}
+	introspectRPS, err := parseIntAllowZero("AS_RATE_LIMIT_INTROSPECT_RPS", defaultIntrospectRPS)
+	if err != nil {
+		return nil, err
+	}
+	introspectBurst, err := parseIntAllowZero("AS_RATE_LIMIT_INTROSPECT_BURST", defaultIntrospectBurst)
+	if err != nil {
+		return nil, err
+	}
+	adminRPS, err := parseIntAllowZero("AS_RATE_LIMIT_ADMIN_RPS", defaultAdminRPS)
+	if err != nil {
+		return nil, err
+	}
+	adminBurst, err := parseIntAllowZero("AS_RATE_LIMIT_ADMIN_BURST", defaultAdminBurst)
+	if err != nil {
+		return nil, err
+	}
+	cfg.AuthorizeRateLimitRPS = authorizeRPS
+	cfg.AuthorizeRateLimitBurst = authorizeBurst
+	cfg.TokenRateLimitRPS = tokenRPS
+	cfg.TokenRateLimitBurst = tokenBurst
+	cfg.IntrospectRateLimitRPS = introspectRPS
+	cfg.IntrospectRateLimitBurst = introspectBurst
+	cfg.AdminRateLimitRPS = adminRPS
+	cfg.AdminRateLimitBurst = adminBurst
 
 	return cfg, nil
 }
@@ -154,6 +222,21 @@ func parseDurationSeconds(env string, fallback int) (time.Duration, error) {
 	return time.Duration(val) * time.Second, nil
 }
 
+func parseDurationSecondsAllowZero(env string, fallback int) (time.Duration, error) {
+	raw := getEnv(env, "")
+	if raw == "" {
+		return time.Duration(fallback) * time.Second, nil
+	}
+	val, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: %w", env, err)
+	}
+	if val < 0 {
+		return 0, fmt.Errorf("%s must be non-negative", env)
+	}
+	return time.Duration(val) * time.Second, nil
+}
+
 func getEnv(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
@@ -174,6 +257,21 @@ func parseBool(env string, fallback bool) (bool, error) {
 	default:
 		return false, fmt.Errorf("invalid %s: %s", env, raw)
 	}
+}
+
+func parseIntAllowZero(env string, fallback int) (int, error) {
+	raw := getEnv(env, "")
+	if raw == "" {
+		return fallback, nil
+	}
+	val, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: %w", env, err)
+	}
+	if val < 0 {
+		return 0, fmt.Errorf("%s must be non-negative", env)
+	}
+	return val, nil
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/jwt/issuer.go
+++ b/internal/jwt/issuer.go
@@ -14,6 +14,9 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
+	"strings"
+	"sync"
 	"time"
 
 	"go_oauth2_server/internal/random"
@@ -24,14 +27,17 @@ type MapClaims map[string]any
 
 // Signer issues JWTs for both regular access tokens and OBO tokens.
 type Signer struct {
-	issuer     string
-	audience   string
-	privateKey *rsa.PrivateKey
-	publicKey  *rsa.PublicKey
-	keyID      string
-	accessTTL  time.Duration
-	refreshTTL time.Duration
-	oboTTL     time.Duration
+	mu          sync.RWMutex
+	issuer      string
+	audience    string
+	privateKey  *rsa.PrivateKey
+	publicKey   *rsa.PublicKey
+	keyID       string
+	publicKeys  map[string]*rsa.PublicKey
+	privateKeys map[string]*rsa.PrivateKey
+	accessTTL   time.Duration
+	refreshTTL  time.Duration
+	oboTTL      time.Duration
 }
 
 var (
@@ -47,20 +53,26 @@ var (
 
 // NewSigner constructs a new Signer instance.
 func NewSigner(issuer, audience string, keyPEM []byte, keyID string, accessTTL, refreshTTL, oboTTL time.Duration) (*Signer, error) {
-	privateKey, err := parseRSAPrivateKey(keyPEM)
+	keySet, err := LoadKeySetFromPEM(keyPEM, keyID)
 	if err != nil {
-		return nil, fmt.Errorf("parse signing key: %w", err)
+		return nil, err
 	}
-	return &Signer{
+	return NewSignerWithKeySet(issuer, audience, keySet, accessTTL, refreshTTL, oboTTL)
+}
+
+// NewSignerWithKeySet constructs a new Signer with a key set.
+func NewSignerWithKeySet(issuer, audience string, keySet *KeySet, accessTTL, refreshTTL, oboTTL time.Duration) (*Signer, error) {
+	signer := &Signer{
 		issuer:     issuer,
 		audience:   audience,
-		privateKey: privateKey,
-		publicKey:  &privateKey.PublicKey,
-		keyID:      keyID,
 		accessTTL:  accessTTL,
 		refreshTTL: refreshTTL,
 		oboTTL:     oboTTL,
-	}, nil
+	}
+	if err := signer.UpdateKeys(keySet); err != nil {
+		return nil, err
+	}
+	return signer, nil
 }
 
 // IssueAccess issues a standard access token for a subject and client.
@@ -138,8 +150,12 @@ func (s *Signer) issue(ctx context.Context, subject, clientID, scope string, per
 		"alg": "RS256",
 		"typ": "JWT",
 	}
-	if s.keyID != "" {
-		header["kid"] = s.keyID
+	keyID, key, err := s.activeKey()
+	if err != nil {
+		return "", 0, err
+	}
+	if keyID != "" {
+		header["kid"] = keyID
 	}
 	headerJSON, err := json.Marshal(header)
 	if err != nil {
@@ -151,7 +167,7 @@ func (s *Signer) issue(ctx context.Context, subject, clientID, scope string, per
 	}
 	tokenUnsigned := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(claimsJSON)
 	hash := sha256.Sum256([]byte(tokenUnsigned))
-	sig, err := rsa.SignPKCS1v15(rand.Reader, s.privateKey, crypto.SHA256, hash[:])
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hash[:])
 	if err != nil {
 		return "", 0, fmt.Errorf("sign token: %w", err)
 	}
@@ -168,13 +184,25 @@ func (s *Signer) Verify(token, expectedAudience string) (MapClaims, error) {
 	if len(parts) != 3 {
 		return nil, errors.New("invalid token format")
 	}
+	header, err := parseJWTHeader(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	if alg, _ := header["alg"].(string); alg != "RS256" {
+		return nil, errors.New("unsupported jwt alg")
+	}
+	kid, _ := header["kid"].(string)
+	publicKey, err := s.publicKeyForKID(kid)
+	if err != nil {
+		return nil, err
+	}
 	unsigned := parts[0] + "." + parts[1]
 	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
 	if err != nil {
 		return nil, fmt.Errorf("decode signature: %w", err)
 	}
 	hash := sha256.Sum256([]byte(unsigned))
-	if err := rsa.VerifyPKCS1v15(s.publicKey, crypto.SHA256, hash[:], sigBytes); err != nil {
+	if err := rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, hash[:], sigBytes); err != nil {
 		return nil, errors.New("signature mismatch")
 	}
 	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
@@ -250,20 +278,35 @@ func asInt(v any) (int64, bool) {
 
 // JWKS returns a JWK set exposing the RSA public key.
 func (s *Signer) JWKS() (map[string]any, error) {
-	if s.publicKey == nil {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.publicKeys) == 0 {
 		return nil, errors.New("missing signing key")
 	}
-	n := base64.RawURLEncoding.EncodeToString(s.publicKey.N.Bytes())
-	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(s.publicKey.E)).Bytes())
-	jwk := map[string]any{
-		"kty": "RSA",
-		"alg": "RS256",
-		"n":   n,
-		"e":   e,
-		"kid": s.keyID,
-		"use": "sig",
+	keyIDs := make([]string, 0, len(s.publicKeys))
+	for keyID := range s.publicKeys {
+		keyIDs = append(keyIDs, keyID)
 	}
-	return map[string]any{"keys": []any{jwk}}, nil
+	sort.Strings(keyIDs)
+	keys := make([]any, 0, len(keyIDs))
+	for _, keyID := range keyIDs {
+		publicKey := s.publicKeys[keyID]
+		if publicKey == nil {
+			continue
+		}
+		n := base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes())
+		e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes())
+		jwk := map[string]any{
+			"kty": "RSA",
+			"alg": "RS256",
+			"n":   n,
+			"e":   e,
+			"kid": keyID,
+			"use": "sig",
+		}
+		keys = append(keys, jwk)
+	}
+	return map[string]any{"keys": keys}, nil
 }
 
 // ComputeSubjectHash returns a stable hash for subject entitlements.
@@ -284,6 +327,64 @@ func (s *Signer) Issuer() string {
 	return s.issuer
 }
 
+// UpdateKeys swaps the active key set for signing and verification.
+func (s *Signer) UpdateKeys(keySet *KeySet) error {
+	if keySet == nil || len(keySet.PrivateKeys) == 0 {
+		return errors.New("missing signing key set")
+	}
+	activeKeyID := keySet.ActiveKeyID
+	if strings.TrimSpace(activeKeyID) == "" {
+		return errors.New("active key id required")
+	}
+	privateKey, ok := keySet.PrivateKeys[activeKeyID]
+	if !ok || privateKey == nil {
+		return fmt.Errorf("active signing key %q not found", activeKeyID)
+	}
+	publicKeys := keySet.PublicKeys
+	if len(publicKeys) == 0 {
+		publicKeys = map[string]*rsa.PublicKey{}
+		for id, key := range keySet.PrivateKeys {
+			if key != nil {
+				publicKeys[id] = &key.PublicKey
+			}
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keyID = activeKeyID
+	s.privateKey = privateKey
+	s.publicKey = &privateKey.PublicKey
+	s.publicKeys = publicKeys
+	s.privateKeys = keySet.PrivateKeys
+	return nil
+}
+
+func (s *Signer) activeKey() (string, *rsa.PrivateKey, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.privateKey == nil {
+		return "", nil, errors.New("missing signing key")
+	}
+	return s.keyID, s.privateKey, nil
+}
+
+func (s *Signer) publicKeyForKID(kid string) (*rsa.PublicKey, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if kid == "" {
+		if s.publicKey == nil {
+			return nil, errors.New("missing signing key")
+		}
+		return s.publicKey, nil
+	}
+	if s.publicKeys != nil {
+		if key, ok := s.publicKeys[kid]; ok && key != nil {
+			return key, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown kid %q", kid)
+}
+
 func parseRSAPrivateKey(keyPEM []byte) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(keyPEM)
 	if block == nil {
@@ -301,6 +402,18 @@ func parseRSAPrivateKey(keyPEM []byte) (*rsa.PrivateKey, error) {
 		return nil, errors.New("not RSA private key")
 	}
 	return key, nil
+}
+
+func parseJWTHeader(headerSegment string) (map[string]any, error) {
+	headerBytes, err := base64.RawURLEncoding.DecodeString(headerSegment)
+	if err != nil {
+		return nil, fmt.Errorf("decode header: %w", err)
+	}
+	var header map[string]any
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return nil, fmt.Errorf("unmarshal header: %w", err)
+	}
+	return header, nil
 }
 
 func stringsSplit(s string, sep rune) []string {

--- a/internal/jwt/keyset.go
+++ b/internal/jwt/keyset.go
@@ -1,0 +1,120 @@
+package jwt
+
+import (
+	"crypto/rsa"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// KeyMeta tracks metadata about a signing key.
+type KeyMeta struct {
+	Source  string
+	ModTime time.Time
+}
+
+// KeySet represents a collection of RSA keys with an active key.
+type KeySet struct {
+	ActiveKeyID string
+	PrivateKeys map[string]*rsa.PrivateKey
+	PublicKeys  map[string]*rsa.PublicKey
+	Meta        map[string]KeyMeta
+}
+
+// LoadKeySetFromPEM loads a single key from PEM.
+func LoadKeySetFromPEM(keyPEM []byte, keyID string) (*KeySet, error) {
+	if len(keyPEM) == 0 {
+		return nil, errors.New("missing signing key")
+	}
+	privateKey, err := parseRSAPrivateKey(keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parse signing key: %w", err)
+	}
+	if strings.TrimSpace(keyID) == "" {
+		keyID = "default"
+	}
+	return &KeySet{
+		ActiveKeyID: keyID,
+		PrivateKeys: map[string]*rsa.PrivateKey{keyID: privateKey},
+		PublicKeys:  map[string]*rsa.PublicKey{keyID: &privateKey.PublicKey},
+		Meta:        map[string]KeyMeta{keyID: {Source: "pem"}},
+	}, nil
+}
+
+// LoadKeySetFromDir loads all PEM keys from a directory.
+func LoadKeySetFromDir(dir string, activeKeyID string) (*KeySet, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil, errors.New("signing key directory required")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read signing key dir: %w", err)
+	}
+	privateKeys := map[string]*rsa.PrivateKey{}
+	publicKeys := map[string]*rsa.PublicKey{}
+	meta := map[string]KeyMeta{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if ext != ".pem" && ext != ".key" {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ext)
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read signing key %s: %w", entry.Name(), err)
+		}
+		privateKey, err := parseRSAPrivateKey(data)
+		if err != nil {
+			return nil, fmt.Errorf("parse signing key %s: %w", entry.Name(), err)
+		}
+		privateKeys[name] = privateKey
+		publicKeys[name] = &privateKey.PublicKey
+		info, err := entry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("stat signing key %s: %w", entry.Name(), err)
+		}
+		meta[name] = KeyMeta{Source: path, ModTime: info.ModTime()}
+	}
+	if len(privateKeys) == 0 {
+		return nil, errors.New("no signing keys found in directory")
+	}
+	activeKeyID = strings.TrimSpace(activeKeyID)
+	if activeKeyID == "" {
+		activeKeyID = newestKey(meta)
+	}
+	if _, ok := privateKeys[activeKeyID]; !ok {
+		return nil, fmt.Errorf("active signing key %q not found", activeKeyID)
+	}
+	return &KeySet{
+		ActiveKeyID: activeKeyID,
+		PrivateKeys: privateKeys,
+		PublicKeys:  publicKeys,
+		Meta:        meta,
+	}, nil
+}
+
+func newestKey(meta map[string]KeyMeta) string {
+	if len(meta) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(meta))
+	for k := range meta {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return meta[keys[i]].ModTime.After(meta[keys[j]].ModTime)
+	})
+	return keys[0]
+}

--- a/internal/obo/obo_test.go
+++ b/internal/obo/obo_test.go
@@ -38,7 +38,11 @@ odOEQaR0ILGMQJZmpfvekDyK
 -----END PRIVATE KEY-----`
 
 func TestResolveAgentIgnoresSubjectAssertionClientID(t *testing.T) {
-	signer, err := internaljwt.NewSigner("issuer", "aud", []byte(testSigningKeyPEM), "", time.Minute, time.Minute, time.Minute)
+	keySet, err := internaljwt.LoadKeySetFromPEM([]byte(testSigningKeyPEM), "test-key")
+	if err != nil {
+		t.Fatalf("init signer: %v", err)
+	}
+	signer, err := internaljwt.NewSignerWithKeySet("issuer", "aud", keySet, time.Minute, time.Minute, time.Minute)
 	if err != nil {
 		t.Fatalf("init signer: %v", err)
 	}

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -1,0 +1,64 @@
+package ratelimit
+
+import (
+	"sync"
+	"time"
+)
+
+type bucket struct {
+	tokens float64
+	last   time.Time
+}
+
+// Limiter is a simple in-memory token bucket rate limiter.
+type Limiter struct {
+	mu    sync.Mutex
+	rate  float64
+	burst float64
+	store map[string]*bucket
+}
+
+// NewLimiter creates a limiter. If rate or burst are non-positive, it returns nil (disabled).
+func NewLimiter(rate float64, burst int) *Limiter {
+	if rate <= 0 || burst <= 0 {
+		return nil
+	}
+	return &Limiter{
+		rate:  rate,
+		burst: float64(burst),
+		store: make(map[string]*bucket),
+	}
+}
+
+// Allow reports whether a request should be allowed for the given key.
+func (l *Limiter) Allow(key string) bool {
+	if l == nil {
+		return true
+	}
+	if key == "" {
+		key = "anonymous"
+	}
+	now := time.Now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	b, ok := l.store[key]
+	if !ok {
+		l.store[key] = &bucket{tokens: l.burst - 1, last: now}
+		return true
+	}
+	elapsed := now.Sub(b.last).Seconds()
+	b.tokens = min(l.burst, b.tokens+elapsed*l.rate)
+	b.last = now
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens -= 1
+	return true
+}
+
+func min(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -8,35 +8,54 @@ import (
 
 // AuthorizationCode represents an authorization code grant.
 type AuthorizationCode struct {
-	Code        string
-	ClientID    string
-	HumanID     string
-	RedirectURI string
-	Scope       string
-	ExpiresAt   time.Time
+	Code                string
+	ClientID            string
+	HumanID             string
+	RedirectURI         string
+	Scope               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	IssuedAt            time.Time
+	ExpiresAt           time.Time
 }
 
 // RefreshToken represents a refresh token record.
 type RefreshToken struct {
-	Token     string
-	ClientID  string
-	HumanID   string
-	Scope     string
-	ExpiresAt time.Time
+	Token      string
+	ClientID   string
+	HumanID    string
+	Scope      string
+	FamilyID   string
+	IssuedAt   time.Time
+	ConsumedAt time.Time
+	ExpiresAt  time.Time
+}
+
+var (
+	ErrRefreshTokenNotFound    = errors.New("refresh token not found")
+	ErrRefreshTokenConsumed    = errors.New("refresh token already used")
+	ErrRefreshTokenFamilyReset = errors.New("refresh token family revoked")
+)
+
+type refreshFamily struct {
+	Revoked   bool
+	RevokedAt time.Time
 }
 
 // Store is an in-memory data store for demo purposes.
 type Store struct {
-	mu            sync.Mutex
-	codes         map[string]AuthorizationCode
-	refreshTokens map[string]RefreshToken
+	mu              sync.Mutex
+	codes           map[string]AuthorizationCode
+	refreshTokens   map[string]RefreshToken
+	refreshFamilies map[string]refreshFamily
 }
 
 // New creates a new Store.
 func New() *Store {
 	return &Store{
-		codes:         make(map[string]AuthorizationCode),
-		refreshTokens: make(map[string]RefreshToken),
+		codes:           make(map[string]AuthorizationCode),
+		refreshTokens:   make(map[string]RefreshToken),
+		refreshFamilies: make(map[string]refreshFamily),
 	}
 }
 
@@ -64,6 +83,11 @@ func (s *Store) SaveRefreshToken(token RefreshToken) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.refreshTokens[token.Token] = token
+	if token.FamilyID != "" {
+		if _, ok := s.refreshFamilies[token.FamilyID]; !ok {
+			s.refreshFamilies[token.FamilyID] = refreshFamily{}
+		}
+	}
 }
 
 // GetRefreshToken retrieves a refresh token.
@@ -71,7 +95,15 @@ func (s *Store) GetRefreshToken(token string) (RefreshToken, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	rt, ok := s.refreshTokens[token]
-	return rt, ok
+	if !ok {
+		return RefreshToken{}, false
+	}
+	if rt.FamilyID != "" {
+		if family, ok := s.refreshFamilies[rt.FamilyID]; ok && family.Revoked {
+			return RefreshToken{}, false
+		}
+	}
+	return rt, true
 }
 
 // DeleteRefreshToken removes a refresh token.
@@ -79,4 +111,56 @@ func (s *Store) DeleteRefreshToken(token string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.refreshTokens, token)
+}
+
+func (s *Store) RotateRefreshToken(token string, next RefreshToken) (RefreshToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.refreshTokens[token]
+	if !ok {
+		return RefreshToken{}, ErrRefreshTokenNotFound
+	}
+	if current.FamilyID != "" {
+		if family, ok := s.refreshFamilies[current.FamilyID]; ok && family.Revoked {
+			return RefreshToken{}, ErrRefreshTokenFamilyReset
+		}
+	}
+	if !current.ConsumedAt.IsZero() {
+		s.revokeFamilyLocked(current.FamilyID)
+		return RefreshToken{}, ErrRefreshTokenConsumed
+	}
+	current.ConsumedAt = time.Now().UTC()
+	s.refreshTokens[token] = current
+	if next.FamilyID == "" {
+		next.FamilyID = current.FamilyID
+	}
+	s.refreshTokens[next.Token] = next
+	if next.FamilyID != "" {
+		if _, ok := s.refreshFamilies[next.FamilyID]; !ok {
+			s.refreshFamilies[next.FamilyID] = refreshFamily{}
+		}
+	}
+	return current, nil
+}
+
+func (s *Store) RevokeRefreshTokenFamily(token string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rt, ok := s.refreshTokens[token]
+	if !ok {
+		return
+	}
+	s.revokeFamilyLocked(rt.FamilyID)
+}
+
+func (s *Store) revokeFamilyLocked(familyID string) {
+	if familyID == "" {
+		return
+	}
+	s.refreshFamilies[familyID] = refreshFamily{Revoked: true, RevokedAt: time.Now().UTC()}
+	for token, rt := range s.refreshTokens {
+		if rt.FamilyID == familyID {
+			delete(s.refreshTokens, token)
+		}
+	}
 }


### PR DESCRIPTION
### Motivation

- The codebase began as a lab and lacked several production-critical protections for OAuth flows such as PKCE, refresh token rotation, and rate limiting. 
- JWT key handling used a single embedded key with no rotation or multi-key JWKS support, increasing operational risk during key changes. 
- The token lifecycle surface was incomplete because introspection and revocation semantics were missing for refresh tokens. 
- Minimal observability and abuse controls left the sensitive endpoints exposed to brute force and replay attacks.

### Description

- Enforced PKCE (S256) for public clients and bound authorization codes to `client_id`, `redirect_uri`, `code_challenge`, `code_challenge_method`, `issued_at`, and TTL by extending `AuthorizationCode` and validating `code_verifier` on token exchange (`cmd/as/main.go`, `internal/store/store.go`).
- Implemented refresh token rotation and reuse detection using refresh families, with `RotateRefreshToken`, family revocation on reuse, and store-level family tracking (`internal/store/store.go` and `cmd/as/main.go`).
- Added `/oauth2/introspect` and `/oauth2/revoke` endpoints with refresh-token-aware semantics and integrated them into the token flow (`cmd/as/main.go`).
- Introduced a small in-memory token-bucket rate limiter and middleware, configurable via environment variables, and applied it to `/oauth2/authorize`, `/oauth2/token`, `/oauth2/introspect`, and the admin API (`internal/ratelimit/limiter.go`, `cmd/as/main.go`, `internal/config/config.go`).
- Reworked key management to support multi-key RSA key sets and optional directory-based loading with an active `kid`, JWKS publication of all loaded keys for overlap, periodic reload scaffolding, and strict header `alg`/`kid` validation (`internal/jwt/keyset.go`, `internal/jwt/issuer.go`, `cmd/as/main.go`, `cmd/rs/main.go`, `internal/config/config.go`).
- Documentation and runbook added and README updated to describe the new production-readiness features and configuration options (`docs/PROD_READINESS_AUDIT.md`, `docs/PROD_READINESS_PLAN.md`, `docs/RUNBOOK.md`, `README.md`).
- Tests expanded to cover PKCE behavior, refresh rotation & reuse detection, introspection/revocation, and rate-limiting behavior, plus minor test harness updates to exercise the new keyset APIs (tests in `cmd/as/main_test.go`, `internal/obo/obo_test.go`).

### Testing

- Ran the full unit test suite with `go test ./...` and all tests passed successfully. 
- Added unit tests exercising PKCE enforcement, refresh token rotation and reuse detection, introspect/revoke flows, and rate limiting, and these new tests pass under the test run. 
- Applied `gofmt` formatting across modified files as part of the change verification. 
- Start / smoke commands are documented in `README.md` and the new docs for manual verification of runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698819c27a4c832cb952eaa481cddf79)